### PR TITLE
Added basic styling for p, h1, ul, and a for spaces 

### DIFF
--- a/app/javascript/stylesheets/common_elements.scss
+++ b/app/javascript/stylesheets/common_elements.scss
@@ -1,6 +1,14 @@
+a,
 .link {
   @apply text-pink-700;
   &:hover {
     @apply underline;
+  }
+}
+
+a.unstyled-link {
+  color: inherit;
+  &:hover {
+    text-decoration: none;
   }
 }

--- a/app/javascript/stylesheets/space.scss
+++ b/app/javascript/stylesheets/space.scss
@@ -1,12 +1,20 @@
 .space {
+  h1, h2, h3 {
+    @apply mt-6 font-bold;
+  }
+
+  p, ul, ol, h3, h2, h1 {
+    @apply mb-3;
+  }
+
   h1 {
-    @apply text-3xl mt-6 mb-3 font-bold;
+    @apply text-3xl;
   }
   h2 {
-    @apply text-2xl mt-6 mb-3 font-bold;
+    @apply text-2xl;
   }
   h3 {
-    @apply text-xl mt-6 mb-3 font-bold;
+    @apply text-xl;
   }
 
   hr {

--- a/app/views/spaces/_space_listing.html.erb
+++ b/app/views/spaces/_space_listing.html.erb
@@ -16,7 +16,7 @@ TODO:
 
 %>
 
-<%= link_to space_path(space) do %>
+<%= link_to space_path(space), class: "unstyled-link" do %>
 
   <div class="mt-4 mb-12 max-w-lg hover:opacity-70">
 


### PR DESCRIPTION
As well as global styling for `<a>`, and an '.unstyled-link' class that can be added to an `<a>` to negate the global styling.