### PR TITLE
Fix scrolling on mobile

### DIFF
--- a/app/javascript/controllers/mapbox_controller.js
+++ b/app/javascript/controllers/mapbox_controller.js
@@ -30,15 +30,27 @@ export default class extends Controller {
       ...options,
     });
 
-    this.map.on('moveend', () => {
-      this.loadNewMapPosition();
-    });
+    this.setupEventCallbacks();
 
     // Hash for storing markers, based on
     // { spaceId: mapBoxMarker }
     this.markers = {};
 
     this.loadNewMapPosition();
+  }
+
+  setupEventCallbacks() {
+    this.loadPositionOn('dragend');
+    this.loadPositionOn('zoomend');
+    this.loadPositionOn('rotateend');
+    this.loadPositionOn('pitchend');
+    this.loadPositionOn('boxzoomend');
+  }
+
+  loadPositionOn(event) {
+    this.map.on(event, () => {
+      this.loadNewMapPosition();
+    });
   }
 
   addMarker(space) {


### PR DESCRIPTION
Fixed issue where scrolling on mobile would sometimes initiate a `moveend` event. The solution I found to this was to simply be more specific about the kind of events we care about, as `moveend` was very generic