### PR TITLE
Show facilities, and tooltip for them

### DIFF
--- a/app/models/aggregated_facility_review.rb
+++ b/app/models/aggregated_facility_review.rb
@@ -5,4 +5,21 @@ class AggregatedFacilityReview < ApplicationRecord
 
   belongs_to :facility
   belongs_to :space
+
+  def tooltip
+    case experience
+    when 'unknown'
+      'Usikkert. Ingen har spurt!'
+    when 'impossible'
+      'Umulig. De har ikke.'
+    when 'unlikely'
+      'Usannsynlig. Ingen eller få har fått lov'
+    when 'maybe'
+      'Kanskje! Ikke alle får lov'
+    when 'likely'
+      'Sannsynlig! Andre har fått lov!'
+    else
+      'Vet ikke'
+    end
+  end
 end

--- a/app/models/facility_category.rb
+++ b/app/models/facility_category.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class FacilityCategory < ApplicationRecord
+  has_many :facilities, dependent: :restrict_with_exception
 end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -28,13 +28,16 @@ class Space < ApplicationRecord
   end
 
   def facilities_in_category(category)
-    Facility.where(facility_category: category).all.map do |facility|
-      review_for_facility = reviews_for_facility(facility)
+    AggregatedFacilityReview
+      .where(space: self)
+      .includes(:facility)
+      .where(facilities: { facility_category: category })
+      .map do |result|
       {
-        title: facility.title,
-        icon: facility.icon,
-        review: review_for_facility.experience,
-        tooltip: review_for_facility.tooltip
+        title: result.facility.title,
+        icon: result.facility.icon,
+        review: result.experience,
+        tooltip: result.tooltip
       }
     end
   end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -29,9 +29,8 @@ class Space < ApplicationRecord
 
   def facilities_in_category(category)
     AggregatedFacilityReview
-      .where(space: self)
       .includes(:facility)
-      .where(facilities: { facility_category: category })
+      .where(space: self, facilities: { facility_category: category })
       .map do |result|
       {
         title: result.facility.title,

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -27,6 +27,18 @@ class Space < ApplicationRecord
     AggregatedFacilityReview.find_by(space: self, facility: facility)
   end
 
+  def facilities_in_category(category)
+    Facility.where(facility_category: category).all.map do |facility|
+      review_for_facility = reviews_for_facility(facility)
+      {
+        title: facility.title,
+        icon: facility.icon,
+        review: review_for_facility.experience,
+        tooltip: review_for_facility.tooltip
+      }
+    end
+  end
+
   def self.rect_of_spaces
     south_west_lat = 90
     south_west_lng = 180

--- a/app/views/spaces/show/_facilities.html.erb
+++ b/app/views/spaces/show/_facilities.html.erb
@@ -1,41 +1,25 @@
 <h2>Fasiliteter</h2>
-<h3>Vi ser etter:</h3>
-MANGLER
 
-<h3>Andre fasiteter:</h3>
+<% FacilityCategory.all.each_with_index do |facilityCategory, index| %>
+  <%=
+    # Header isn't needed if these are just the normal facilities, and
+    # we don't have any selected. When we do get 'filtered' or 'selected'
+    # facilities ("Facilities we are looking for"), also the first facilityCategory
+    # header should be included as "Andre fasiliteter"
+    tag.h3 facilityCategory.title unless index == 0
+  %>
 
-<ul class="grid grid-cols-2 gap-2 mt-2">
-  <li class="flex items-center gap-1.5" title="Sannsynlig! Andre har fått lov">
-    Overnatting
-    <span>
-           <%= inline_svg_tag 'facility_status/likely' %>
-        </span>
-  </li>
-  <li class="flex items-center gap-1.5"  title="Usannsynlig: Ingen eller få har fått lov">
-    Kjøkken
-    <span>
-           <%= inline_svg_tag 'facility_status/unlikely' %>
-        </span>
-  </li>
-  <li class="flex items-center gap-1.5" title="Kanskje: Ikke alle får lov">
-    Dansegulv
-    <span>
-           <%= inline_svg_tag 'facility_status/maybe' %>
-        </span>
-  </li>
-  <li class="flex items-center gap-1.5" title="Usikkert: Ingen har spurt om lydanlegg">
-    Lydanlegg
-    <span>
-           <%= inline_svg_tag 'facility_status/unknown' %>
-        </span>
-  </li>
-  <li class="flex items-center gap-1.5" title="Umulig: Frederik II har ikke flyplass">
-    Flyplass
-    <span>
-           <%= inline_svg_tag 'facility_status/impossible' %>
-        </span>
-  </li>
-</ul>
-
-<h3>Er lokalet universelt utformet?</h3>
-MANGLER
+  <ul class="grid grid-cols-2 gap-2 mt-2">
+    <% @space.facilities_in_category(facilityCategory).each do |facility| %>
+      <li
+        class="flex items-center gap-1.5"
+        title="<%= facility[:tooltip] %>">
+        <%= inline_svg "facilities/#{facility[:icon]}" %>
+        <%= facility[:title] %>
+        <span>
+         <%= inline_svg_tag "facility_status/#{facility[:review]}" %>
+      </span>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/db/seeds/defaults/a11y_facilities.rb
+++ b/db/seeds/defaults/a11y_facilities.rb
@@ -25,7 +25,7 @@ facilities = [
   }
 ]
 
-category = FacilityCategory.find_or_create_by(title: 'Universell utforming')
+category = FacilityCategory.find_or_create_by(title: 'Er lokalet universelt uformet?')
 
 facilities.each do |facility|
   Facility.find_or_create_by(


### PR DESCRIPTION
This PR adds facilities like this to each Space#show:

![image](https://user-images.githubusercontent.com/14905290/136411144-0dca2c7f-b370-4692-bd0b-10197ebbaef6.png)

To get it to work properly, you might have to re-run seeds with db:reset, or you will get the wrong titles for each category. 

It introduces some new code that I'm uncertain about, and would love a review on!

In particular, looking for reviews on the `tooltip` method I added to AggregatedFacilityReview. Is that the right place for it?
![image](https://user-images.githubusercontent.com/14905290/136410540-be0f7daf-5188-4197-a79d-c7fada2e7282.png)


Also looking for a review on how to efficiently join AggregatedFacilityReview data with Facility data for a given Space. Currently I do it through Ruby, and I'm almost certain there must be a better way to do it through SQL / ActiveRecord: 

![image](https://user-images.githubusercontent.com/14905290/136410695-7cd6da9f-6f97-4b9f-877e-fa4cced8fc7e.png)

We also get some technical debt in the partial `_facilities.html.erb` and afforamentioned methods by not modelling the future "Facilities we have selected" feature right now. I think that's for the better, as it can be added later. 

![image](https://user-images.githubusercontent.com/14905290/136410958-511b8c4a-8140-4d5f-847b-056bb9452479.png)
