### PR TITLE
Changes to paper trail config, to make it ready for versions in the future

### DIFF
--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Space < ApplicationRecord
-  has_paper_trail
+  has_paper_trail skip: [:star_rating]
+
   has_many_attached :images
   has_many :facility_reviews, dependent: :restrict_with_exception
   has_many :aggregated_facility_reviews, dependent: :restrict_with_exception

--- a/config/initializers/action_text_paper_trail.rb
+++ b/config/initializers/action_text_paper_trail.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+ActiveSupport.on_load(:action_text_rich_text) do
+  ActionText::RichText.class_eval do
+    has_paper_trail
+  end
+end

--- a/db/migrate/20211011115122_add_object_changes_to_versions.rb
+++ b/db/migrate/20211011115122_add_object_changes_to_versions.rb
@@ -1,0 +1,6 @@
+class AddObjectChangesToVersions < ActiveRecord::Migration[6.1]
+  def change
+    # Adds diff to paper trail
+    add_column :versions, :object_changes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_114554) do
+ActiveRecord::Schema.define(version: 2021_10_11_115122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -158,6 +158,7 @@ ActiveRecord::Schema.define(version: 2021_10_05_114554) do
     t.string "whodunnit"
     t.text "object"
     t.datetime "created_at"
+    t.text "object_changes"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 


### PR DESCRIPTION
Experimented a little with paper trail to see if it fit our demands, and found it lacking for actiontext, diffs, and star ratings. 

This PR adds paper trail to actiontext, skip star rating for paper trail (as it's generated by reviews, not versioned), and add diffs to paper trail.

To use for actionText:

```ruby
@space..who_can_book.versions # Paper trail for who_can_book. Same syntax for other rich text fields.

# Compared to normal paper trail:

@space.versions # Paper trail for title, fits_people, address and all the other basic information
```

To see diff for a given version:
``` ruby
@space.versions.last.changeset 
```