### PR TITLE
Autofill address when creating space

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ end
 group :test do
   gem 'capybara'
   gem 'rspec-rails'
+  gem 'vcr'
+  gem 'webmock'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'devise', '~> 4.8'
 
 gem 'gravtastic'
 gem 'hotwire-rails'
+gem 'http'
 gem 'inline_svg'
 gem 'paper_trail'
 gem 'sendgrid-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     devise (4.8.0)
       bcrypt (~> 3.0)
@@ -131,6 +133,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hashdiff (1.0.1)
     hotwire-rails (0.1.3)
       rails (>= 6.0.0)
       stimulus-rails
@@ -339,6 +342,7 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.0.0)
+    vcr (6.0.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -346,6 +350,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -399,7 +407,9 @@ DEPENDENCIES
   tailwindcss-rails-webpacker (~> 0.1.2)
   turbolinks (~> 5)
   tzinfo-data
+  vcr
   web-console (>= 4.1.0)
+  webmock
   webpacker (~> 5.0)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -102,6 +104,9 @@ GEM
     faker (2.18.0)
       i18n (>= 1.6, < 2)
     ffi (1.15.4)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     foreman (0.87.2)
     formatador (0.2.5)
     globalid (0.5.2)
@@ -130,6 +135,14 @@ GEM
       rails (>= 6.0.0)
       stimulus-rails
       turbo-rails
+    http (5.0.4)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     http_parser.rb (0.6.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -145,6 +158,9 @@ GEM
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -319,6 +335,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
     unicode-display_width (2.0.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -357,6 +376,7 @@ DEPENDENCIES
   guard-livereload
   guard-rspec
   hotwire-rails
+  http
   image_processing
   inline_svg
   jbuilder (~> 2.7)

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -16,7 +16,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
 
     @space = Space.create!(
       **space_params,
-      **address_params.to_h
+      **address_params
     )
 
     redirect_to space_path(@space)
@@ -31,7 +31,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
 
     return render json: { map_image_html: helpers.static_map_of_lat_lng(lat: nil, lng: nil) } if address.nil?
 
-    render json: { **address.to_h, map_image_html: helpers.static_map_of_lat_lng(lat: address.lat, lng: address.lng) }
+    render json: { **address, map_image_html: helpers.static_map_of_lat_lng(lat: address[:lat], lng: address[:lng]) }
   end
 
   def edit
@@ -49,7 +49,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
     address_params = get_address_params(params)
     if @space.update(
       **space_params,
-      **address_params.to_h
+      **address_params
     )
       redirect_to space_path(@space)
     else
@@ -104,7 +104,6 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
   private
 
   def get_address_params(params)
-    # Returns OpenStruct as defined in location_search_service
     Space.search_for_address(
       address: params[:space][:address],
       post_number: params[:space][:post_number],

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -40,7 +40,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
 
     return render json: nil if address.nil?
 
-    render json: address.to_h
+    render json: { **address.to_h, map_image_html: helpers.static_map_of_lat_lng(lat: address.lat, lng: address.lng) }
   end
 
   def edit

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -11,15 +11,14 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
   end
 
   def create # rubocop:disable Metrics/AbcSize
-    addresses = Space.search_for_address(
+    address = Space.search_for_address(
       address: params[:space][:address],
       post_number: params[:space][:post_number],
       post_address: params[:space][:post_address]
     )
 
-    return redirect_to spaces_path, alert: 'Unable to find address' if addresses.count > 1 || addresses.empty?
+    return redirect_to spaces_path, alert: 'Unable to find address' if address.nil?
 
-    address = addresses.first
     @space = Space.create!(
       **space_params,
       address: address.address,
@@ -33,15 +32,15 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
   end
 
   def address_search
-    addresses = Space.search_for_address(
+    address = Space.search_for_address(
       address: params[:address],
       post_number: params[:post_number],
       post_address: params[:post_address]
     )
 
-    return render json: nil if addresses.count > 1 || addresses.empty?
+    return render json: nil if address.nil?
 
-    render json: addresses.first.to_h
+    render json: address.to_h
   end
 
   def edit

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -12,7 +12,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
 
   def create
     address_params = get_address_params(params)
-    return redirect_to spaces_path, alert: 'Unable to find address' if address_params.nil?
+    return redirect_to spaces_path, alert: t('address_search.didnt_find') if address_params.nil?
 
     @space = Space.create!(
       **space_params,

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -10,22 +10,13 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
     @space = Space.find(params[:id])
   end
 
-  def create # rubocop:disable Metrics/AbcSize
-    address = Space.search_for_address(
-      address: params[:space][:address],
-      post_number: params[:space][:post_number],
-      post_address: params[:space][:post_address]
-    )
-
-    return redirect_to spaces_path, alert: 'Unable to find address' if address.nil?
+  def create
+    address_params = get_address_params(params)
+    return redirect_to spaces_path, alert: 'Unable to find address' if address_params.nil?
 
     @space = Space.create!(
       **space_params,
-      address: address.address,
-      post_address: address.post_address,
-      post_number: address.post_number,
-      lat: address.lat,
-      lng: address.lng
+      **address_params.to_h
     )
 
     redirect_to space_path(@space)
@@ -38,7 +29,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
       post_address: params[:post_address]
     )
 
-    return render json: nil if address.nil?
+    return render json: { map_image_html: helpers.static_map_of_lat_lng(lat: nil, lng: nil) } if address.nil?
 
     render json: { **address.to_h, map_image_html: helpers.static_map_of_lat_lng(lat: address.lat, lng: address.lng) }
   end
@@ -55,8 +46,11 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
 
   def update
     @space = Space.find(params[:id])
-
-    if @space.update(space_params)
+    address_params = get_address_params(params)
+    if @space.update(
+      **space_params,
+      **address_params.to_h
+    )
       redirect_to space_path(@space)
     else
       render :edit, status: :unprocessable_entity
@@ -108,6 +102,15 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
   end
 
   private
+
+  def get_address_params(params)
+    # Returns OpenStruct as defined in location_search_service
+    Space.search_for_address(
+      address: params[:space][:address],
+      post_number: params[:space][:post_number],
+      post_address: params[:space][:post_address]
+    )
+  end
 
   def filter_spaces(params)
     space_types = params[:space_types]&.map(&:to_i)

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -18,8 +18,15 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
     return redirect_to spaces_path, alert: 'Unable to find address' if addresses.count > 1 || addresses.empty?
 
     address = addresses.first
-    @space = Space.create!(space_type: space_type, **space_params, address: address.address,
-                           post_number: address.post_number, lat: address.lat, lng: address.lng)
+    @space = Space.create!(
+      space_type: space_type,
+      **space_params,
+      address: address.address,
+      post_address: address.post_address,
+      post_number: address.post_number,
+      lat: address.lat,
+      lng: address.lng
+    )
 
     redirect_to space_path(@space)
   end
@@ -27,7 +34,8 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
   def address_search
     Spaces::LocationSearchService.call(
       address: params[:space][:address],
-      post_number: params[:space][:post_number]
+      post_number: params[:space][:post_number],
+      post_address: params[:space][:post_address]
     )
   end
 

--- a/app/helpers/spaces_helper.rb
+++ b/app/helpers/spaces_helper.rb
@@ -49,6 +49,8 @@ module SpacesHelper
   end
 
   def static_map_of_lat_lng(lat:, lng:, zoom: 12, height: 250, width: 400, **html_options) # rubocop:disable Metrics/ParameterLists
+    return static_map_placeholder(height: height, width: width, html_options: html_options) if lat.nil? || lng.nil?
+
     color_of_pin = 'db2777' # Tailwind pink-600
     static_map_image_url = [
       'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static',
@@ -60,6 +62,13 @@ module SpacesHelper
       "&access_token=#{ENV['MAPBOX_API_KEY']}"
     ].join
     image_tag static_map_image_url, html_options
+  end
+
+  def static_map_placeholder(height: 250, width: 400, **html_options)
+    tag.div t('address_search.didnt_find'),
+            style: "height: #{height}px; max-width: #{width}px",
+            class: 'bg-gray-100 border border-gray-200 flex justify-center items-center text-center',
+            **html_options
   end
 
   # Generates a link to an external map (Google maps, for example)

--- a/app/helpers/spaces_helper.rb
+++ b/app/helpers/spaces_helper.rb
@@ -38,11 +38,22 @@ module SpacesHelper
   # Can also be combined with HTML attributes for the iamge tag
   # static_map_of @space, zoom: 4, class: "p-4"
   def static_map_of(space, zoom: 12, height: 250, width: 400, **html_options)
+    static_map_of_lat_lng(
+      lat: space.lat,
+      lng: space.lng,
+      zoom: zoom,
+      height: height,
+      width: width,
+      html_options: html_options
+    )
+  end
+
+  def static_map_of_lat_lng(lat:, lng:, zoom: 12, height: 250, width: 400, **html_options) # rubocop:disable Metrics/ParameterLists
     color_of_pin = 'db2777' # Tailwind pink-600
     static_map_image_url = [
       'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static',
-      "/pin-l-circle+#{color_of_pin}(#{space.lng},#{space.lat})", # Type, color, and position of pin
-      "/#{space.lng},#{space.lat},#{zoom}", # Position of map
+      "/pin-l-circle+#{color_of_pin}(#{lng},#{lat})", # Type, color, and position of pin
+      "/#{lng},#{lat},#{zoom}", # Position of map
       "/#{width}x#{height}", # Size of map
       '?logo=false', # Hide mapbox logo
       '&@2x', # Render at 2x for retina

--- a/app/javascript/controllers/autofilladdress_controller.js
+++ b/app/javascript/controllers/autofilladdress_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ["address", "postNumber", "postAddress", "municipalityCode"]
+
+  async connect() {
+    this.addressTarget.onchange = () => { this.updateFields() };
+    this.postNumberTarget.onchange = () => { this.updateFields() };
+    this.postAddressTarget.onchange = () => { this.updateFields() };
+  }
+
+  async updateFields() {
+    const url = [
+      `/address_search?`,
+      `address=${this.addressTarget.value}&`,
+      `post_number=${this.postNumberTarget.value}&`,
+      `post_address=${this.postAddressTarget.value}`].join('');
+
+    const result = await (await fetch(url)).json();
+
+    if(result == null)
+      return;
+
+    this.addressTarget.value = result.address;
+    this.postNumberTarget.value = result.post_number;
+    this.postAddressTarget.value = result.post_address;
+    this.municipalityCodeTarget.value = result.municipality_code;
+  }
+}

--- a/app/javascript/controllers/autofilladdress_controller.js
+++ b/app/javascript/controllers/autofilladdress_controller.js
@@ -21,8 +21,6 @@ export default class extends Controller {
     if(result == null)
       return;
 
-    console.log(result.map_image_html)
-
     this.addressTarget.value = result.address;
     this.postNumberTarget.value = result.post_number;
     this.postAddressTarget.value = result.post_address;

--- a/app/javascript/controllers/autofilladdress_controller.js
+++ b/app/javascript/controllers/autofilladdress_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ["address", "postNumber", "postAddress", "municipalityCode", "mapHolder"]
+  static targets = ["address", "postNumber", "postAddress", "mapHolder"]
 
   async connect() {
     this.addressTarget.onchange = () => { this.updateFields() };
@@ -18,13 +18,12 @@ export default class extends Controller {
 
     const result = await (await fetch(url)).json();
 
-    if(result == null)
-      return;
+    if (result && result.address) {
+      this.addressTarget.value = result.address;
+      this.postNumberTarget.value = result.post_number;
+      this.postAddressTarget.value = result.post_address;
+    }
 
-    this.addressTarget.value = result.address;
-    this.postNumberTarget.value = result.post_number;
-    this.postAddressTarget.value = result.post_address;
-    this.municipalityCodeTarget.value = result.municipality_code;
     this.mapHolderTarget.innerHTML = result.map_image_html;
   }
 }

--- a/app/javascript/controllers/autofilladdress_controller.js
+++ b/app/javascript/controllers/autofilladdress_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
-  static targets = ["address", "postNumber", "postAddress", "municipalityCode"]
+  static targets = ["address", "postNumber", "postAddress", "municipalityCode", "mapHolder"]
 
   async connect() {
     this.addressTarget.onchange = () => { this.updateFields() };
@@ -21,9 +21,12 @@ export default class extends Controller {
     if(result == null)
       return;
 
+    console.log(result.map_image_html)
+
     this.addressTarget.value = result.address;
     this.postNumberTarget.value = result.post_number;
     this.postAddressTarget.value = result.post_address;
     this.municipalityCodeTarget.value = result.municipality_code;
+    this.mapHolderTarget.innerHTML = result.map_image_html;
   }
 }

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -80,11 +80,15 @@ class Space < ApplicationRecord
   end
 
   def self.search_for_address(address:, post_number:, post_address:)
-    Spaces::LocationSearchService.call(
+    results = Spaces::LocationSearchService.call(
       address: address,
       post_number: post_number,
       post_address: post_address
     )
+
+    return nil if results.count > 1 || results.empty?
+
+    results.first
   end
 
   # Move this somewhere better, either a service or figure out a way to make it a scope

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -79,6 +79,14 @@ class Space < ApplicationRecord
     Spaces::AggregateStarRatingService.call(space: self)
   end
 
+  def self.search_for_address(address:, post_number:, post_address:)
+    Spaces::LocationSearchService.call(
+      address: address,
+      post_number: post_number,
+      post_address: post_address
+    )
+  end
+
   # Move this somewhere better, either a service or figure out a way to make it a scope
   # NOTE: this expects a scope for spaces but returns an array
   # preferably we would find some way to return a scope too

--- a/app/services/spaces/location_search_service.rb
+++ b/app/services/spaces/location_search_service.rb
@@ -37,12 +37,14 @@ module Spaces
 
       result['adresser'].map do |address|
         point = address['representasjonspunkt']
-        OpenStruct.new(lat: point['lat'],
-                       lng: point['lon'],
-                       address: address['adressetekst'],
-                       post_number: address['postnummer'],
-                       post_address: address['poststed'],
-                       municipality_code: address['kommunenummer'])
+        {
+          lat: point['lat'],
+          lng: point['lon'],
+          address: address['adressetekst'],
+          post_number: address['postnummer'],
+          post_address: address['poststed'],
+          municipality_code: address['kommunenummer']
+        }
       end
     end
 

--- a/app/services/spaces/location_search_service.rb
+++ b/app/services/spaces/location_search_service.rb
@@ -33,6 +33,8 @@ module Spaces
     def call
       result = JSON.parse(HTTP.get(build_url).body)
 
+      return [] if result['adresser'].nil?
+
       result['adresser'].map do |address|
         point = address['representasjonspunkt']
         OpenStruct.new(lat: point['lat'],

--- a/app/services/spaces/location_search_service.rb
+++ b/app/services/spaces/location_search_service.rb
@@ -20,10 +20,10 @@ module Spaces
           'utkoordsys=4258&',
           'treffPerSide=10&',
           'side=0&',
-          'asciiKompatibel=true&',
-          "sok=#{address}"
+          'asciiKompatibel=true'
         ].join
 
+      url += "&sok=#{address}" if address.present?
       url += "&postnummer=#{post_number}" if post_number.present?
       url
     end

--- a/app/services/spaces/location_search_service.rb
+++ b/app/services/spaces/location_search_service.rb
@@ -6,9 +6,10 @@ module Spaces
   class LocationSearchService < ApplicationService
     URL = 'https://ws.geonorge.no/adresser/v1/sok?'
 
-    def initialize(address:, post_number:)
+    def initialize(address: nil, post_number: nil, post_address: nil)
       @address = address
       @post_number = post_number
+      @post_address = post_address
 
       super()
     end
@@ -25,6 +26,7 @@ module Spaces
 
       url += "&sok=#{address}" if address.present?
       url += "&postnummer=#{post_number}" if post_number.present?
+      url += "&poststed=#{post_address}" if post_address.present?
       url
     end
 
@@ -37,12 +39,13 @@ module Spaces
                        lng: point['lon'],
                        address: address['adressetekst'],
                        post_number: address['postnummer'],
+                       post_address: address['poststed'],
                        municipality_code: address['kommunenummer'])
       end
     end
 
     private
 
-    attr_reader :address, :post_number
+    attr_reader :address, :post_number, :post_address
   end
 end

--- a/app/services/spaces/location_search_service.rb
+++ b/app/services/spaces/location_search_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'http'
+
+module Spaces
+  class LocationSearchService < ApplicationService
+    URL = 'https://ws.geonorge.no/adresser/v1/sok?'
+
+    def initialize(address:, post_number:)
+      @address = address
+      @post_number = post_number
+
+      super()
+    end
+
+    def build_url
+      url =
+        [
+          URL,
+          'utkoordsys=4258&',
+          'treffPerSide=10&',
+          'side=0&',
+          'asciiKompatibel=true&',
+          "sok=#{address}"
+        ].join
+
+      url += "&postnummer=#{post_number}" if post_number.present?
+      url
+    end
+
+    def call
+      result = JSON.parse(HTTP.get(build_url).body)
+
+      result['adresser'].map do |address|
+        point = address['representasjonspunkt']
+        OpenStruct.new(lat: point['lat'],
+                       lng: point['lon'],
+                       address: address['adressetekst'],
+                       post_number: address['postnummer'],
+                       municipality_code: address['kommunenummer'])
+      end
+    end
+
+    private
+
+    attr_reader :address, :post_number
+  end
+end

--- a/app/views/spaces/create/_form.html.erb
+++ b/app/views/spaces/create/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: space do |form| %>
   <%= edit_field 'title', form %>
-  <%= edit_field 'address', form %>
+  <%= edit_field 'where', form %>
   <%= edit_field 'organization_number', form %>
   <%= edit_field 'fits_people', form %>
   <%= edit_field 'how_to_book', form %>

--- a/app/views/spaces/edit/_address.html.erb
+++ b/app/views/spaces/edit/_address.html.erb
@@ -15,11 +15,3 @@
   <%= form.text_field :municipality_code, class: "border-4" %>
 </div>
 
-<div>
-  <%= form.label :latitude %>
-  <%= form.number_field :lat, step: 0.0001, class: "border-4" %>
-</div>
-<div>
-  <%= form.label :longitude %>
-  <%= form.number_field :lng, step: 0.0001, class: "border-4" %>
-</div>

--- a/app/views/spaces/edit/_address.html.erb
+++ b/app/views/spaces/edit/_address.html.erb
@@ -15,4 +15,7 @@
     <%= form.label :municipality_code %>
     <%= form.text_field :municipality_code, data: { "autofilladdress-target": "municipalityCode" }, class: "border-4" %>
   </div>
+
+  <div data-autofilladdress-target="mapHolder">
+  </div>
 </div>

--- a/app/views/spaces/edit/_address.html.erb
+++ b/app/views/spaces/edit/_address.html.erb
@@ -1,17 +1,18 @@
-<div>
-  <%= form.label :address %>
-  <%= form.text_field :address, class: "border-4" %>
+<div data-controller="autofilladdress">
+  <div>
+    <%= form.label :address %>
+    <%= form.text_field :address, data: { "autofilladdress-target": "address" }, class: "border-4" %>
+  </div>
+  <div>
+    <%= form.label :post_number %>
+    <%= form.text_field :post_number, data: { "autofilladdress-target": "postNumber" }, class: "border-4" %>
+  </div>
+  <div>
+    <%= form.label :post_address %>
+    <%= form.text_field :post_address, data: { "autofilladdress-target": "postAddress" }, class: "border-4" %>
+  </div>
+  <div>
+    <%= form.label :municipality_code %>
+    <%= form.text_field :municipality_code, data: { "autofilladdress-target": "municipalityCode" }, class: "border-4" %>
+  </div>
 </div>
-<div>
-  <%= form.label :post_number %>
-  <%= form.text_field :post_number, class: "border-4" %>
-</div>
-<div>
-  <%= form.label :post_address %>
-  <%= form.text_field :post_address, class: "border-4" %>
-</div>
-<div>
-  <%= form.label :municipality_code %>
-  <%= form.text_field :municipality_code, class: "border-4" %>
-</div>
-

--- a/app/views/spaces/edit/_basics.html.erb
+++ b/app/views/spaces/edit/_basics.html.erb
@@ -13,7 +13,6 @@
   <%= form.number_field :fits_people, class: "border-4" %>
 </div>
 
-
 <div>
   <%= form.label :space_owner_id %>
   <%= form.collection_select :space_owner_id, SpaceOwner.all, :id, :title, class: "border-4" %>
@@ -24,19 +23,21 @@
   <%= form.text_field :organization_number, class: "border-4" %>
 </div>
 
-
 <div>
   <%= form.label :address %>
   <%= form.text_field :address, class: "border-4" %>
 </div>
+
 <div>
   <%= form.label :post_number %>
   <%= form.text_field :post_number, class: "border-4" %>
 </div>
+
 <div>
   <%= form.label :post_address %>
   <%= form.text_field :post_address, class: "border-4" %>
 </div>
+
 <div>
   <%= form.label :municipality_code %>
   <%= form.text_field :municipality_code, class: "border-4" %>
@@ -46,6 +47,7 @@
   <%= form.label :latitude %>
   <%= form.number_field :lat, step: 0.0001, class: "border-4" %>
 </div>
+
 <div>
   <%= form.label :longitude %>
   <%= form.number_field :lng, step: 0.0001, class: "border-4" %>

--- a/app/views/spaces/edit/_basics.html.erb
+++ b/app/views/spaces/edit/_basics.html.erb
@@ -23,32 +23,6 @@
   <%= form.text_field :organization_number, class: "border-4" %>
 </div>
 
-<div>
-  <%= form.label :address %>
-  <%= form.text_field :address, class: "border-4" %>
-</div>
-
-<div>
-  <%= form.label :post_number %>
-  <%= form.text_field :post_number, class: "border-4" %>
-</div>
-
-<div>
-  <%= form.label :post_address %>
-  <%= form.text_field :post_address, class: "border-4" %>
-</div>
-
-<div>
-  <%= form.label :municipality_code %>
-  <%= form.text_field :municipality_code, class: "border-4" %>
-</div>
-
-<div>
-  <%= form.label :latitude %>
-  <%= form.number_field :lat, step: 0.0001, class: "border-4" %>
-</div>
-
-<div>
-  <%= form.label :longitude %>
-  <%= form.number_field :lng, step: 0.0001, class: "border-4" %>
-</div>
+<%= render partial: 'spaces/edit/where', locals: {
+  form: form
+} %>

--- a/app/views/spaces/edit/_where.html.erb
+++ b/app/views/spaces/edit/_where.html.erb
@@ -11,11 +11,8 @@
     <%= form.label :post_address %>
     <%= form.text_field :post_address, data: { "autofilladdress-target": "postAddress" }, class: "border-4" %>
   </div>
-  <div>
-    <%= form.label :municipality_code %>
-    <%= form.text_field :municipality_code, data: { "autofilladdress-target": "municipalityCode" }, class: "border-4" %>
-  </div>
 
   <div data-autofilladdress-target="mapHolder">
+    <%= render partial: "spaces/show/static_map" %>
   </div>
 </div>

--- a/app/views/spaces/show/_where.html.erb
+++ b/app/views/spaces/show/_where.html.erb
@@ -1,4 +1,4 @@
-<%= inline_editable :address  do %>
+<%= inline_editable :where  do %>
 
   <div class="flex gap-1 mb-3">
     <%= inline_svg_tag 'place' %>

--- a/config/definitions.rb
+++ b/config/definitions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+# The following comments fill some of the gaps in Solargraph's understanding of
+# Rails apps. Since they're all in YARD, they get mapped in Solargraph but
+# ignored at runtime.
+#
+# You can put this file anywhere in the project, as long as it gets included in
+# the workspace maps. It's recommended that you keep it in a standalone file
+# instead of pasting it into an existing one.
+#
+# @!parse
+#   class ActionController::Base
+#     include ActionController::MimeResponds
+#     extend ActiveSupport::Callbacks::ClassMethods
+#     extend AbstractController::Callbacks::ClassMethods
+#   end
+#   class ActiveRecord::Base
+#     extend ActiveRecord::QueryMethods
+#     extend ActiveRecord::FinderMethods
+#     extend ActiveRecord::Associations::ClassMethods
+#     extend ActiveRecord::Inheritance::ClassMethods
+#     include ActiveRecord::Persistence
+#   end
+# @!override ActiveRecord::FinderMethods#find
+#   @overload find(id)
+#     @param id [Integer]
+#     @return [self]
+#   @overload find(list)
+#     @param list [Array]
+#     @return [Array<self>]
+#   @overload find(*args)
+#     @return [Array<self>]
+#   @return [self, Array<self>]

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -12,6 +12,8 @@ nb:
       unlikely: 'Usannsynlig. Ingen eller få har fått lov'
       maybe: 'Kanskje! Ikke alle for lov'
       likely: 'Sannsynlig: Andre har fått lov!'
+  address_search:
+    didnt_find: 'Fant ikke adressen'
   space_listing:
     no_results: 'Ingen resultater'
   space_show:
@@ -48,7 +50,10 @@ nb:
         more_info: 'Mer om lokalet'
         terms: 'Vilkår for å bruke lokalet'
         pricing: 'Pris'
-        address: 'Hvor er det?'
+        where: 'Hvor er det?'
+        address: 'Adresse'
+        post_number: 'Postnummer'
+        post_address: 'Poststed'
   read_more: 'Les mer'
 
   devise:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   get '/spaces/:id/edit/:field', to: 'spaces#edit_field', as: 'edit_field'
   get 'spaces_search', to: 'spaces#spaces_search'
   get 'rect_for_spaces', to: 'spaces#rect_for_spaces'
+  get 'address_search', to: 'spaces#address_search'
   post 'spaces/upload_image', to: 'spaces#upload_image'
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'vcr'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -66,4 +67,10 @@ RSpec.configure do |config|
 
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::ControllerHelpers, type: :controller
+
+
+  VCR.configure do |config|
+    config.cassette_library_dir = "spec/support/vcr"
+    config.hook_into :webmock
+  end
 end

--- a/spec/services/spaces/location_search_service_spec.rb
+++ b/spec/services/spaces/location_search_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Spaces::LocationSearchService do
+  it 'searches only on address' do
+    VCR.use_cassette('location_search_address') do
+      expect(described_class.call(address: 'Hammerstads gate 32', post_number: nil).count).to eq(1)
+    end
+  end
+
+  it 'searches only on postcode' do
+    VCR.use_cassette('location_search_postcode') do
+      expect(described_class.call(address: nil, post_number: 3060).count).to eq(10)
+    end
+  end
+
+  it 'searches on address and postcode' do
+    VCR.use_cassette('location_search_address_postcode') do
+      expect(described_class.call(address: 'Ankerveien 2', post_number: 3060).count).to eq(1)
+    end
+  end
+end

--- a/spec/services/spaces/location_search_service_spec.rb
+++ b/spec/services/spaces/location_search_service_spec.rb
@@ -5,13 +5,19 @@ require 'rails_helper'
 RSpec.describe Spaces::LocationSearchService do
   it 'searches only on address' do
     VCR.use_cassette('location_search_address') do
-      expect(described_class.call(address: 'Hammerstads gate 32', post_number: nil).count).to eq(1)
+      expect(described_class.call(address: 'Hammerstads gate 32').count).to eq(1)
     end
   end
 
   it 'searches only on postcode' do
     VCR.use_cassette('location_search_postcode') do
-      expect(described_class.call(address: nil, post_number: 3060).count).to eq(10)
+      expect(described_class.call(post_number: 3060, post_address: 'svelvik').count).to eq(10)
+    end
+  end
+
+  it 'searches only on postaddress' do
+    VCR.use_cassette('location_search_postaddress') do
+      expect(described_class.call(post_address: 'svelvik').count).to eq(10)
     end
   end
 

--- a/spec/support/vcr/location_search_address.yml
+++ b/spec/support/vcr/location_search_address.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 29 Oct 2021 11:07:55 GMT
+      - Fri, 29 Oct 2021 12:36:37 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -43,5 +43,5 @@ http_interactions:
         gate 32","totaltAntallTreff":1,"treffPerSide":10,"viserFra":0,"viserTil":10}}
 
         '
-  recorded_at: Fri, 29 Oct 2021 11:07:55 GMT
+  recorded_at: Fri, 29 Oct 2021 12:36:37 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr/location_search_address.yml
+++ b/spec/support/vcr/location_search_address.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://ws.geonorge.no/adresser/v1/sok?asciiKompatibel=true&side=0&sok=Hammerstads%20gate%2032&treffPerSide=10&utkoordsys=4258
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - ws.geonorge.no
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 29 Oct 2021 11:07:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '854'
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+    body:
+      encoding: ASCII-8BIT
+      string: '{"adresser":[{"adressekode":12647,"adressenavn":"Hammerstads gate","adressetekst":"Hammerstads
+        gate 32","adressetekstutenadressetilleggsnavn":"Hammerstads gate 32","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":["H0101","H0102","H0201","H0202","H0301","H0302","H0401","H0402"],"bruksnummer":16,"festenummer":0,"gardsnummer":46,"kommunenavn":"OSLO","kommunenummer":"0301","nummer":32,"objtype":"Vegadresse","oppdateringsdato":"2020-06-15T16:04:04","postnummer":"0363","poststed":"OSLO","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.93178961408748,"lon":10.717497338316784},"stedfestingverifisert":false,"undernummer":null}],"metadata":{"asciiKompatibel":true,"side":0,"sokeStreng":"utkoordsys=4258&treffPerSide=10&side=0&asciiKompatibel=true&sok=Hammerstads
+        gate 32","totaltAntallTreff":1,"treffPerSide":10,"viserFra":0,"viserTil":10}}
+
+        '
+  recorded_at: Fri, 29 Oct 2021 11:07:55 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr/location_search_address_postcode.yml
+++ b/spec/support/vcr/location_search_address_postcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 29 Oct 2021 11:07:56 GMT
+      - Fri, 29 Oct 2021 12:36:37 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -43,5 +43,5 @@ http_interactions:
         2&postnummer=3060","totaltAntallTreff":1,"treffPerSide":10,"viserFra":0,"viserTil":10}}
 
         '
-  recorded_at: Fri, 29 Oct 2021 11:07:56 GMT
+  recorded_at: Fri, 29 Oct 2021 12:36:37 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr/location_search_address_postcode.yml
+++ b/spec/support/vcr/location_search_address_postcode.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://ws.geonorge.no/adresser/v1/sok?asciiKompatibel=true&postnummer=3060&side=0&sok=Ankerveien%202&treffPerSide=10&utkoordsys=4258
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - ws.geonorge.no
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 29 Oct 2021 11:07:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '787'
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+    body:
+      encoding: ASCII-8BIT
+      string: '{"adresser":[{"adressekode":5005,"adressenavn":"Ankerveien","adressetekst":"Ankerveien
+        2","adressetekstutenadressetilleggsnavn":"Ankerveien 2","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":337,"festenummer":0,"gardsnummer":321,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":2,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.622597692013315,"lon":10.392915337658497},"stedfestingverifisert":false,"undernummer":null}],"metadata":{"asciiKompatibel":true,"side":0,"sokeStreng":"utkoordsys=4258&treffPerSide=10&side=0&asciiKompatibel=true&sok=Ankerveien
+        2&postnummer=3060","totaltAntallTreff":1,"treffPerSide":10,"viserFra":0,"viserTil":10}}
+
+        '
+  recorded_at: Fri, 29 Oct 2021 11:07:56 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/vcr/location_search_postaddress.yml
+++ b/spec/support/vcr/location_search_postaddress.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://ws.geonorge.no/adresser/v1/sok?asciiKompatibel=true&postnummer=3060&poststed=svelvik&side=0&treffPerSide=10&utkoordsys=4258
+    uri: https://ws.geonorge.no/adresser/v1/sok?asciiKompatibel=true&poststed=svelvik&side=0&treffPerSide=10&utkoordsys=4258
     body:
       encoding: UTF-8
       string: ''
@@ -21,11 +21,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 29 Oct 2021 12:36:18 GMT
+      - Fri, 29 Oct 2021 12:37:27 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '5927'
+      - '5911'
       Connection:
       - close
       Access-Control-Allow-Origin:
@@ -48,8 +48,8 @@ http_interactions:
         14","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 14","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":63,"festenummer":0,"gardsnummer":312,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":14,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59097600743437,"lon":10.402943433827314},"stedfestingverifisert":false,"undernummer":null},{"adressekode":5038,"adressenavn":"Boker\u00f8yveien","adressetekst":"Boker\u00f8yveien
         12","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 12","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":57,"festenummer":0,"gardsnummer":312,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":12,"objtype":"Vegadresse","oppdateringsdato":"2021-05-19T06:23:23","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59051374649466,"lon":10.402499077717527},"stedfestingverifisert":true,"undernummer":null},{"adressekode":5038,"adressenavn":"Boker\u00f8yveien","adressetekst":"Boker\u00f8yveien
         22","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 22","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":56,"festenummer":0,"gardsnummer":312,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":22,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59174300832563,"lon":10.403613058996523},"stedfestingverifisert":false,"undernummer":null},{"adressekode":5038,"adressenavn":"Boker\u00f8yveien","adressetekst":"Boker\u00f8yveien
-        21","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 21","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":1,"festenummer":0,"gardsnummer":316,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":21,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59151745931449,"lon":10.408143512319288},"stedfestingverifisert":false,"undernummer":null}],"metadata":{"asciiKompatibel":true,"side":0,"sokeStreng":"utkoordsys=4258&treffPerSide=10&side=0&asciiKompatibel=true&postnummer=3060&poststed=svelvik","totaltAntallTreff":2851,"treffPerSide":10,"viserFra":0,"viserTil":10}}
+        21","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 21","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":1,"festenummer":0,"gardsnummer":316,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":21,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59151745931449,"lon":10.408143512319288},"stedfestingverifisert":false,"undernummer":null}],"metadata":{"asciiKompatibel":true,"side":0,"sokeStreng":"utkoordsys=4258&treffPerSide=10&side=0&asciiKompatibel=true&poststed=svelvik","totaltAntallTreff":2851,"treffPerSide":10,"viserFra":0,"viserTil":10}}
 
         '
-  recorded_at: Fri, 29 Oct 2021 12:36:18 GMT
+  recorded_at: Fri, 29 Oct 2021 12:37:27 GMT
 recorded_with: VCR 6.0.0

--- a/spec/support/vcr/location_search_postcode.yml
+++ b/spec/support/vcr/location_search_postcode.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://ws.geonorge.no/adresser/v1/sok?asciiKompatibel=true&postnummer=3060&side=0&treffPerSide=10&utkoordsys=4258
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - ws.geonorge.no
+      User-Agent:
+      - http.rb/5.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 29 Oct 2021 11:07:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5910'
+      Connection:
+      - close
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range
+      Access-Control-Expose-Headers:
+      - Content-Length,Content-Range
+    body:
+      encoding: ASCII-8BIT
+      string: '{"adresser":[{"adressekode":5136,"adressenavn":"Gjerrudveien","adressetekst":"Gjerrudveien
+        48A","adressetekstutenadressetilleggsnavn":"Gjerrudveien 48A","adressetilleggsnavn":null,"bokstav":"A","bruksenhetsnummer":[],"bruksnummer":7,"festenummer":0,"gardsnummer":328,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":48,"objtype":"Vegadresse","oppdateringsdato":"2021-09-14T07:56:56","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.65254280759855,"lon":10.372673203838243},"stedfestingverifisert":false,"undernummer":null},{"adressekode":5335,"adressenavn":"Orelundveien","adressetekst":"Orelundveien
+        1","adressetekstutenadressetilleggsnavn":"Orelundveien 1","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":151,"festenummer":0,"gardsnummer":322,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":1,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.61642637827625,"lon":10.401631023622443},"stedfestingverifisert":true,"undernummer":null},{"adressekode":5335,"adressenavn":"Orelundveien","adressetekst":"Orelundveien
+        3A","adressetekstutenadressetilleggsnavn":"Orelundveien 3A","adressetilleggsnavn":null,"bokstav":"A","bruksenhetsnummer":[],"bruksnummer":152,"festenummer":0,"gardsnummer":322,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":3,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.6164331915551,"lon":10.402253495283233},"stedfestingverifisert":true,"undernummer":null},{"adressekode":5130,"adressenavn":"Fjordgl\u00f8ttveien","adressetekst":"Fjordgl\u00f8ttveien
+        13","adressetekstutenadressetilleggsnavn":"Fjordgl\u00f8ttveien 13","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":180,"festenummer":0,"gardsnummer":318,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":13,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.612579020302846,"lon":10.403379651098053},"stedfestingverifisert":false,"undernummer":null},{"adressekode":5421,"adressenavn":"Skjoldveien","adressetekst":"Skjoldveien
+        10A","adressetekstutenadressetilleggsnavn":"Skjoldveien 10A","adressetilleggsnavn":null,"bokstav":"A","bruksenhetsnummer":[],"bruksnummer":139,"festenummer":0,"gardsnummer":322,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":10,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.615999898754325,"lon":10.395559859086651},"stedfestingverifisert":false,"undernummer":null},{"adressekode":5038,"adressenavn":"Boker\u00f8yveien","adressetekst":"Boker\u00f8yveien
+        28","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 28","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":62,"festenummer":0,"gardsnummer":312,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":28,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59113524764947,"lon":10.404845340901849},"stedfestingverifisert":false,"undernummer":null},{"adressekode":5038,"adressenavn":"Boker\u00f8yveien","adressetekst":"Boker\u00f8yveien
+        14","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 14","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":63,"festenummer":0,"gardsnummer":312,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":14,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59097600743437,"lon":10.402943433827314},"stedfestingverifisert":false,"undernummer":null},{"adressekode":5038,"adressenavn":"Boker\u00f8yveien","adressetekst":"Boker\u00f8yveien
+        12","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 12","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":57,"festenummer":0,"gardsnummer":312,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":12,"objtype":"Vegadresse","oppdateringsdato":"2021-05-19T06:23:23","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59051374649466,"lon":10.402499077717527},"stedfestingverifisert":true,"undernummer":null},{"adressekode":5038,"adressenavn":"Boker\u00f8yveien","adressetekst":"Boker\u00f8yveien
+        22","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 22","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":56,"festenummer":0,"gardsnummer":312,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":22,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59174300832563,"lon":10.403613058996523},"stedfestingverifisert":false,"undernummer":null},{"adressekode":5038,"adressenavn":"Boker\u00f8yveien","adressetekst":"Boker\u00f8yveien
+        21","adressetekstutenadressetilleggsnavn":"Boker\u00f8yveien 21","adressetilleggsnavn":null,"bokstav":"","bruksenhetsnummer":[],"bruksnummer":1,"festenummer":0,"gardsnummer":316,"kommunenavn":"DRAMMEN","kommunenummer":"3005","nummer":21,"objtype":"Vegadresse","oppdateringsdato":"2021-01-14T18:45:45","postnummer":"3060","poststed":"SVELVIK","representasjonspunkt":{"epsg":"EPSG:4258","lat":59.59151745931449,"lon":10.408143512319288},"stedfestingverifisert":false,"undernummer":null}],"metadata":{"asciiKompatibel":true,"side":0,"sokeStreng":"utkoordsys=4258&treffPerSide=10&side=0&asciiKompatibel=true&postnummer=3060","totaltAntallTreff":2851,"treffPerSide":10,"viserFra":0,"viserTil":10}}
+
+        '
+  recorded_at: Fri, 29 Oct 2021 11:07:56 GMT
+recorded_with: VCR 6.0.0

--- a/spec/views/spaces/show.html.erb_spec.rb
+++ b/spec/views/spaces/show.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'spaces/show', type: :view do
     expect(rendered).to match /space_#{space.id}-how_to_book/
     expect(rendered).to match /space_#{space.id}-who_can_use/
     expect(rendered).to match /space_#{space.id}-pricing/
-    expect(rendered).to match /space_#{space.id}-address/
+    expect(rendered).to match /space_#{space.id}-where/
     expect(rendered).to match /space_#{space.id}-more_info/
     expect(rendered).to match /space_#{space.id}-terms/
   end


### PR DESCRIPTION
No design work has been done here, it still uses the  green create space CRUD on the main page

It works by the frontend sending a query to the backend which uses Geonorge API to figure out the lat lng of the typed address. if there is no javascript enabled on the frontend the fields will not automatically fill out but the backend will still try to figure out the coordinates based on what was submitted in the form.
