### PR TITLE
Fix flaky specs

### DIFF
--- a/app/services/spaces/aggregate_facility_reviews_service.rb
+++ b/app/services/spaces/aggregate_facility_reviews_service.rb
@@ -28,7 +28,7 @@ module Spaces
 
     private
 
-    def aggregate_reviews(aggregated_review) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    def aggregate_reviews(aggregated_review) # rubocop:disable Metrics/AbcSize
       reviews = space.facility_reviews.where(facility: aggregated_review.facility).order(created_at: :desc).limit(5)
       count = reviews.count
       return aggregated_review.unknown! if count.zero?

--- a/spec/fabricators/facility_category_fabricator.rb
+++ b/spec/fabricators/facility_category_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:facility_category) do
-  title { Faker::Lorem.sentences(number: 1) }
+  title { Faker::Name.first_name }
 end

--- a/spec/fabricators/facility_fabricator.rb
+++ b/spec/fabricators/facility_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:facility) do
-  title { Faker::Lorem.sentences(number: 1) }
+  title { Faker::Name.first_name }
   icon { Faker::Name.first_name }
   facility_category
 end

--- a/spec/fabricators/organization_fabricator.rb
+++ b/spec/fabricators/organization_fabricator.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Fabricator(:organization) do
-  name { Faker::Name.name }
+  name { Faker::Name.first_name }
 end

--- a/spec/fabricators/space_fabricator.rb
+++ b/spec/fabricators/space_fabricator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Fabricator(:space) do
-  title { Faker::Name.name }
+  title { Faker::Name.first_name }
   address { Faker::Address.full_address }
   lat { Faker::Address.latitude }
   lng { Faker::Address.longitude }


### PR DESCRIPTION
Because Faker::Name.name could include ' the html view test matchers would fail to find it example: `Barryl O'Keef`
in html the ' is replaced with `&apos;` and the test would fail.
Faker::Name.first_name should not do this