### PR TITLE
Change rubocop string literal style to double_quotes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ require:
 Style/Documentation:
   Enabled: false
 
+Style/StringLiterals:
+  EnforcedStyle: double_quotes # To always allow #{interpolation}, and reduce fatigue from changing strings
+
 Rails/HasAndBelongsToMany:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,78 +1,78 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.2'
+ruby "3.0.2"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
-gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
+gem "rails", "~> 6.1.4", ">= 6.1.4.1"
 # Use postgresql as the database for Active Record
-gem 'pg', '~> 1.1'
+gem "pg", "~> 1.1"
 # Use Puma as the app server
-gem 'puma', '~> 5.0'
+gem "puma", "~> 5.0"
 # Use SCSS for stylesheets
-gem 'sass-rails', '>= 6'
+gem "sass-rails", ">= 6"
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker', '~> 5.0'
+gem "webpacker", "~> 5.0"
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.7'
+gem "jbuilder", "~> 2.7"
 # Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 4.0'
+gem "redis", "~> 4.0"
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-gem 'image_processing'
+gem "image_processing"
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.4.4', require: false
+gem "bootsnap", ">= 1.4.4", require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'dotenv-rails'
-  gem 'fabrication'
-  gem 'faker'
+  gem "byebug", platforms: %i[mri mingw x64_mingw]
+  gem "dotenv-rails"
+  gem "fabrication"
+  gem "faker"
 end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 4.1.0'
+  gem "web-console", ">= 4.1.0"
   # Display performance information such as SQL time and flame graphs for each request in your browser.
   # Can be configured to work on production as well see: https://github.com/MiniProfiler/rack-mini-profiler/blob/master/README.md
-  gem 'foreman'
-  gem 'guard'
-  gem 'guard-livereload', require: false
-  gem 'guard-rspec', require: false
-  gem 'listen', '~> 3.3'
-  gem 'overcommit'
-  gem 'rack-mini-profiler', '~> 2.0'
-  gem 'rails-erd'
-  gem 'rubocop', require: false
-  gem 'rubocop-performance'
-  gem 'rubocop-rails'
-  gem 'rubocop-rspec'
+  gem "foreman"
+  gem "guard"
+  gem "guard-livereload", require: false
+  gem "guard-rspec", require: false
+  gem "listen", "~> 3.3"
+  gem "overcommit"
+  gem "rack-mini-profiler", "~> 2.0"
+  gem "rails-erd"
+  gem "rubocop", require: false
+  gem "rubocop-performance"
+  gem "rubocop-rails"
+  gem "rubocop-rspec"
 end
 
 group :test do
-  gem 'capybara'
-  gem 'rspec-rails'
-  gem 'vcr'
-  gem 'webmock'
+  gem "capybara"
+  gem "rspec-rails"
+  gem "vcr"
+  gem "webmock"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
-gem 'devise', '~> 4.8'
+gem "devise", "~> 4.8"
 
-gem 'gravtastic'
-gem 'hotwire-rails'
-gem 'http'
-gem 'inline_svg'
-gem 'paper_trail'
-gem 'sendgrid-ruby'
-gem 'tailwindcss-rails-webpacker', '~> 0.1.2'
+gem "gravtastic"
+gem "hotwire-rails"
+gem "http"
+gem "inline_svg"
+gem "paper_trail"
+gem "sendgrid-ruby"
+gem "tailwindcss-rails-webpacker", "~> 0.1.2"

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -12,7 +12,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
 
   def create
     address_params = get_address_params(params)
-    return redirect_to spaces_path, alert: t('address_search.didnt_find') if address_params.nil?
+    return redirect_to spaces_path, alert: t("address_search.didnt_find") if address_params.nil?
 
     @space = Space.create!(
       **space_params,
@@ -41,7 +41,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
   def edit_field
     @space = Space.find(params[:id])
     @field = params[:field]
-    render 'spaces/edit/common/edit_field'
+    render "spaces/edit/common/edit_field"
   end
 
   def update
@@ -84,7 +84,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
     spaces = filter_spaces(params).first(20)
 
     markers = spaces.map do |space|
-      html = render_to_string partial: 'spaces/index/map_marker', locals: { space: space }
+      html = render_to_string partial: "spaces/index/map_marker", locals: { space: space }
       {
         lat: space.lat,
         lng: space.lng,
@@ -95,7 +95,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
 
     render json: {
       listing: render_to_string(
-        partial: 'spaces/index/space_listings', locals: { spaces: spaces.first(10) }
+        partial: "spaces/index/space_listings", locals: { spaces: spaces.first(10) }
       ),
       markers: markers
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,10 +3,10 @@
 module ApplicationHelper
   def helper_flash_type(msg_type, message)
     case msg_type
-    when 'notice'
-      render partial: 'shared/notice', locals: { message: message }
-    when 'alert'
-      render partial: 'shared/alert', locals: { message: message }
+    when "notice"
+      render partial: "shared/notice", locals: { message: message }
+    when "alert"
+      render partial: "shared/alert", locals: { message: message }
     end
   end
 end

--- a/app/helpers/spaces_helper.rb
+++ b/app/helpers/spaces_helper.rb
@@ -6,7 +6,7 @@ module SpacesHelper
   end
 
   def inline_editable(field, title_tag = :h2, title_text = Space.human_attribute_name(field), &block)
-    render partial: 'spaces/edit/common/editable_inline', locals: {
+    render partial: "spaces/edit/common/editable_inline", locals: {
       field: field,
       title_tag: title_tag,
       title_text: title_text,
@@ -20,7 +20,7 @@ module SpacesHelper
     field_in_space = (space.public_send(field) if space.respond_to?(field) && space.public_send(field).present?)
     field_in_space_owner = (owner.public_send(field) if owner.respond_to?(field) && owner.public_send(field).present?)
 
-    render partial: 'spaces/show/common/render_space_and_owner_field', locals: {
+    render partial: "spaces/show/common/render_space_and_owner_field", locals: {
       field_in_space: field_in_space,
       field_in_space_owner: field_in_space_owner
     }
@@ -51,23 +51,23 @@ module SpacesHelper
   def static_map_of_lat_lng(lat:, lng:, zoom: 12, height: 250, width: 400, **html_options) # rubocop:disable Metrics/ParameterLists
     return static_map_placeholder(height: height, width: width, html_options: html_options) if lat.nil? || lng.nil?
 
-    color_of_pin = 'db2777' # Tailwind pink-600
+    color_of_pin = "db2777" # Tailwind pink-600
     static_map_image_url = [
-      'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static',
+      "https://api.mapbox.com/styles/v1/mapbox/streets-v11/static",
       "/pin-l-circle+#{color_of_pin}(#{lng},#{lat})", # Type, color, and position of pin
       "/#{lng},#{lat},#{zoom}", # Position of map
       "/#{width}x#{height}", # Size of map
-      '?logo=false', # Hide mapbox logo
-      '&@2x', # Render at 2x for retina
+      "?logo=false", # Hide mapbox logo
+      "&@2x", # Render at 2x for retina
       "&access_token=#{ENV['MAPBOX_API_KEY']}"
     ].join
     image_tag static_map_image_url, html_options
   end
 
   def static_map_placeholder(height: 250, width: 400, **html_options)
-    tag.div t('address_search.didnt_find'),
+    tag.div t("address_search.didnt_find"),
             style: "height: #{height}px; max-width: #{width}px",
-            class: 'bg-gray-100 border border-gray-200 flex justify-center items-center text-center',
+            class: "bg-gray-100 border border-gray-200 flex justify-center items-center text-center",
             **html_options
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -5,7 +5,7 @@ class DeviseMailer < Devise::Mailer
 
   def reset_password_instructions(record, token, _opts)
     SendgridMailer.send(record.email,
-                        ENV['SENDGRID_RESET_TEMPLATE_ID'],
+                        ENV["SENDGRID_RESET_TEMPLATE_ID"],
                         user_id: record.id,
                         url: Rails.application.routes.url_helpers.edit_user_password_url(@resource, reset_password_token: token)) # rubocop:disable Layout/LineLength
   end

--- a/app/mailers/sendgrid_mailer.rb
+++ b/app/mailers/sendgrid_mailer.rb
@@ -17,12 +17,12 @@ class SendgridMailer
         }
       ],
       from: {
-        email: ENV['SENDGRID_FROM_EMAIL']
+        email: ENV["SENDGRID_FROM_EMAIL"]
       },
       template_id: template_id
     }
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-    response = sg.client.mail._('send').post(request_body: data)
+    sg = SendGrid::API.new(api_key: ENV["SENDGRID_API_KEY"])
+    response = sg.client.mail._("send").post(request_body: data)
 
     response.status_code
   end

--- a/app/models/facility_review.rb
+++ b/app/models/facility_review.rb
@@ -17,13 +17,13 @@ class FacilityReview < ApplicationRecord
 
   def experience_icon
     case experience
-    when 'was_allowed'
+    when "was_allowed"
       :likely
-    when 'was_allowed_but_bad'
+    when "was_allowed_but_bad"
       :maybe
-    when 'was_not_allowed'
+    when "was_not_allowed"
       :unlikely
-    when 'was_not_available'
+    when "was_not_available"
       :impossible
     else
       :unknown

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -12,7 +12,7 @@ class Space < ApplicationRecord
   accepts_nested_attributes_for :space_owner
   scope :filter_on_space_types, ->(space_type_ids) { where(space_type_id: space_type_ids) }
   scope :filter_on_location, lambda { |north_west_lat, north_west_lng, south_east_lat, south_east_lng|
-    where(':north_west_lat >= lat AND :north_west_lng <= lng AND :south_east_lat <= lat AND :south_east_lng >= lng',
+    where(":north_west_lat >= lat AND :north_west_lng <= lng AND :south_east_lat <= lat AND :south_east_lng >= lng",
           north_west_lat: north_west_lat,
           north_west_lng: north_west_lng,
           south_east_lat: south_east_lat,
@@ -118,6 +118,6 @@ class Space < ApplicationRecord
   end
 
   def star_rating_s
-    star_rating || ' - '
+    star_rating || " - "
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   include Gravtastic
-  gravtastic default: 'retro'
+  gravtastic default: "retro"
 
   has_many :reviews, dependent: :restrict_with_exception
   has_and_belongs_to_many :organizations

--- a/app/services/spaces/aggregate_facility_reviews_service.rb
+++ b/app/services/spaces/aggregate_facility_reviews_service.rb
@@ -12,7 +12,7 @@ module Spaces
       space.reload
 
       aggregated_reviews = Facility.all.order(:created_at).map do |facility|
-        AggregatedFacilityReview.create!(experience: 'unknown', space: space, facility: facility)
+        AggregatedFacilityReview.create!(experience: "unknown", space: space, facility: facility)
       end
 
       # Start a transaction because we may be modifying the 'experience' field many times

--- a/app/services/spaces/location_search_service.rb
+++ b/app/services/spaces/location_search_service.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'http'
+require "http"
 
 module Spaces
   class LocationSearchService < ApplicationService
-    URL = 'https://ws.geonorge.no/adresser/v1/sok?'
+    URL = "https://ws.geonorge.no/adresser/v1/sok?"
 
     def initialize(address: nil, post_number: nil, post_address: nil)
       @address = address
@@ -18,10 +18,10 @@ module Spaces
       url =
         [
           URL,
-          'utkoordsys=4258&',
-          'treffPerSide=10&',
-          'side=0&',
-          'asciiKompatibel=true'
+          "utkoordsys=4258&",
+          "treffPerSide=10&",
+          "side=0&",
+          "asciiKompatibel=true"
         ].join
 
       url += "&sok=#{address}" if address.present?
@@ -33,17 +33,17 @@ module Spaces
     def call
       result = JSON.parse(HTTP.get(build_url).body)
 
-      return [] if result['adresser'].nil?
+      return [] if result["adresser"].nil?
 
-      result['adresser'].map do |address|
-        point = address['representasjonspunkt']
+      result["adresser"].map do |address|
+        point = address["representasjonspunkt"]
         {
-          lat: point['lat'],
-          lng: point['lon'],
-          address: address['adressetekst'],
-          post_number: address['postnummer'],
-          post_address: address['poststed'],
-          municipality_code: address['kommunenummer']
+          lat: point["lat"],
+          lng: point["lon"],
+          address: address["adressetekst"],
+          post_number: address["postnummer"],
+          post_address: address["poststed"],
+          municipality_code: address["kommunenummer"]
         }
       end
     end

--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,7 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application
 Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails'
+require "rails"
 # Pick the frameworks you want:
-require 'active_model/railtie'
-require 'active_job/railtie'
-require 'active_record/railtie'
-require 'active_storage/engine'
-require 'action_controller/railtie'
-require 'action_mailer/railtie'
-require 'action_mailbox/engine'
-require 'action_text/engine'
-require 'action_view/railtie'
-require 'action_cable/engine'
-require 'sprockets/railtie'
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_mailbox/engine"
+require "action_text/engine"
+require "action_view/railtie"
+require "action_cable/engine"
+require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/integer/time'
+require "active_support/core_ext/integer/time"
 
 Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Settings specified here will take precedence over those in config/application.rb.
@@ -18,13 +18,13 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
@@ -76,9 +76,9 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+  Rails.application.routes.default_url_options[:host] = "localhost:3000"
 
   # Allow IP from Docker
   # Check if we use Docker to allow docker ip through web-console
-  config.web_console.whitelisted_ips = ['10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16'] if ENV['DOCKERIZED'] == 'true'
+  config.web_console.whitelisted_ips = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"] if ENV["DOCKERIZED"] == "true"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/integer/time'
+require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -24,7 +24,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
@@ -93,7 +93,7 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/integer/time'
+require "active_support/core_ext/integer/time"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -21,7 +21,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,12 +3,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -7,4 +7,4 @@
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
 # by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
-Rails.backtrace_cleaner.remove_silencers! if ENV['BACKTRACE']
+Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,25 +6,25 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
-min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
+worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch('PORT', 3000)
+port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV', 'development')
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,33 +2,33 @@
 
 Rails.application.routes.draw do
   devise_for :users,
-             path: '',
+             path: "",
              path_names: {
-               sign_in: 'signin',
-               sign_out: 'signout',
-               sign_up: 'signup'
+               sign_in: "signin",
+               sign_out: "signout",
+               sign_up: "signup"
              }
 
   devise_scope :user do
     authenticated :user do
-      root to: 'spaces#index'
+      root to: "spaces#index"
     end
   end
 
-  root to: 'devise/sessions#new', as: 'unauthenticated_root'
+  root to: "devise/sessions#new", as: "unauthenticated_root"
 
   # Resources
-  resources 'facilities', except: 'new'
-  resources 'space_owners', except: 'new'
-  resources 'reviews'
+  resources "facilities", except: "new"
+  resources "space_owners", except: "new"
+  resources "reviews"
 
   # Spaces routes
-  resources 'spaces', except: 'new'
-  get '/spaces/:id/edit/:field', to: 'spaces#edit_field', as: 'edit_field'
-  get 'spaces_search', to: 'spaces#spaces_search'
-  get 'rect_for_spaces', to: 'spaces#rect_for_spaces'
-  get 'address_search', to: 'spaces#address_search'
-  post 'spaces/upload_image', to: 'spaces#upload_image'
+  resources "spaces", except: "new"
+  get "/spaces/:id/edit/:field", to: "spaces#edit_field", as: "edit_field"
+  get "spaces_search", to: "spaces#spaces_search"
+  get "rect_for_spaces", to: "spaces#rect_for_spaces"
+  get "address_search", to: "spaces#address_search"
+  post "spaces/upload_image", to: "spaces#upload_image"
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 Spring.watch(
-  '.ruby-version',
-  '.rbenv-vars',
-  'tmp/restart.txt',
-  'tmp/caching-dev.txt'
+  ".ruby-version",
+  ".rbenv-vars",
+  "tmp/restart.txt",
+  "tmp/caching-dev.txt"
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,7 @@
 # Load seeds based on environment::
 ActiveRecord::Base.transaction do
   [Rails.env].each do |possible_seed_file|
-    file = Rails.root.join('db', 'seeds', "#{possible_seed_file}.rb")
+    file = Rails.root.join("db", "seeds", "#{possible_seed_file}.rb")
     next unless File.exist?(file)
 
     # rubocop:disable  Rails/Output

--- a/db/seeds/common.rb
+++ b/db/seeds/common.rb
@@ -2,5 +2,5 @@
 
 # Seeds that are common to both production and development
 
-require './db/seeds/defaults/common_facilities'
-require './db/seeds/defaults/a11y_facilities'
+require "./db/seeds/defaults/common_facilities"
+require "./db/seeds/defaults/a11y_facilities"

--- a/db/seeds/defaults/a11y_facilities.rb
+++ b/db/seeds/defaults/a11y_facilities.rb
@@ -4,28 +4,28 @@
 
 facilities = [
   {
-    title: 'Inngang',
-    icon: 'a11y_entrance'
+    title: "Inngang",
+    icon: "a11y_entrance"
   },
   {
-    title: 'Toalett',
-    icon: 'a11y_toilets'
+    title: "Toalett",
+    icon: "a11y_toilets"
   },
   {
-    title: 'Ledelinje',
-    icon: 'a11y_floor_guidelines'
+    title: "Ledelinje",
+    icon: "a11y_floor_guidelines"
   },
   {
-    title: 'Teleslynge',
-    icon: 'a11y_teleloop'
+    title: "Teleslynge",
+    icon: "a11y_teleloop"
   },
   {
-    title: 'Heis',
-    icon: 'a11y_elevator'
+    title: "Heis",
+    icon: "a11y_elevator"
   }
 ]
 
-category = FacilityCategory.find_or_create_by(title: 'Er lokalet universelt uformet?')
+category = FacilityCategory.find_or_create_by(title: "Er lokalet universelt uformet?")
 
 facilities.each do |facility|
   Facility.find_or_create_by(

--- a/db/seeds/defaults/common_facilities.rb
+++ b/db/seeds/defaults/common_facilities.rb
@@ -4,40 +4,40 @@
 
 facilities = [
   {
-    title: 'Overnatting',
-    icon: 'sleepovers'
+    title: "Overnatting",
+    icon: "sleepovers"
   },
   {
-    title: 'Dusjer',
-    icon: 'showers'
+    title: "Dusjer",
+    icon: "showers"
   },
   {
-    title: 'Klasserom',
-    icon: 'classroom'
+    title: "Klasserom",
+    icon: "classroom"
   },
   {
-    title: 'Auditorium',
-    icon: 'auditorium'
+    title: "Auditorium",
+    icon: "auditorium"
   },
   {
-    title: 'Gymsal',
-    icon: 'gymnasium'
+    title: "Gymsal",
+    icon: "gymnasium"
   },
   {
-    title: 'Kjøkken',
-    icon: 'kitchen'
+    title: "Kjøkken",
+    icon: "kitchen"
   },
   {
-    title: 'Spisesal',
-    icon: 'dining_room'
+    title: "Spisesal",
+    icon: "dining_room"
   },
   {
-    title: 'Prosjektor',
-    icon: 'projector'
+    title: "Prosjektor",
+    icon: "projector"
   }
 ]
 
-category = FacilityCategory.find_or_create_by(title: 'Vanlige')
+category = FacilityCategory.find_or_create_by(title: "Vanlige")
 
 facilities.each do |facility|
   Facility.find_or_create_by(

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 # Common seeds:
-require './db/seeds/common'
+require "./db/seeds/common"
 
 # Development only seeds
 
 ## Create a User:
 User.create(
-  email: 'user@example.com',
-  password: 'user_password',
-  password_confirmation: 'user_password',
-  first_name: 'Kari',
-  last_name: 'Nordmann'
+  email: "user@example.com",
+  password: "user_password",
+  password_confirmation: "user_password",
+  first_name: "Kari",
+  last_name: "Nordmann"
 )
 
 # Fake, empty Space data for Gudeberg school:
-require './db/seeds/spaces/gudeberg_no_info'
+require "./db/seeds/spaces/gudeberg_no_info"
 
 # Fake school that does not want to be listed
-require './db/seeds/spaces/nabbetorp_no_booking'
+require "./db/seeds/spaces/nabbetorp_no_booking"
 
 # Fake, full Space data for Frederik II
-require './db/seeds/spaces/frederikii_full_space'
+require "./db/seeds/spaces/frederikii_full_space"

--- a/db/seeds/production.rb
+++ b/db/seeds/production.rb
@@ -3,4 +3,4 @@
 # Production seeds
 
 # Common seeds:
-require './db/seeds/common'
+require "./db/seeds/common"

--- a/db/seeds/reviews/reviews.rb
+++ b/db/seeds/reviews/reviews.rb
@@ -14,7 +14,7 @@ Fikk ikke bruke kjøkkenet (pga allergier), men fikk lov til å bruke spisesal o
   user.organizations << org
 
   positive_review = Review.create(
-    title: 'Ryddig og hyggelig skole!',
+    title: "Ryddig og hyggelig skole!",
     user: user,
     price: 5400,
     comment: positive_review_comment,
@@ -62,7 +62,7 @@ Greit nok at vi rota litt sist vi var der, men det går nå raskt å vaske!'
   negative_user.organizations << negative_org
 
   negative_review = Review.create(
-    title: 'Ville ikke la oss overnatte!',
+    title: "Ville ikke la oss overnatte!",
     user: negative_user,
     comment: negative_review_comment,
     star_rating: nil,

--- a/db/seeds/space_owners/viken.rb
+++ b/db/seeds/space_owners/viken.rb
@@ -23,8 +23,8 @@ def create_viken # rubocop:disable Metrics/MethodLength
     veileder (PDF)</a></p>'
 
   SpaceOwner.create(
-    title: 'Viken fylkeskommune',
-    orgnr: '921693230',
+    title: "Viken fylkeskommune",
+    orgnr: "921693230",
     how_to_book: how_to_book,
     pricing: pricing,
     terms: terms,

--- a/db/seeds/spaces/frederikii_full_space.rb
+++ b/db/seeds/spaces/frederikii_full_space.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 ## Space Owner
-require './db/seeds/space_owners/viken'
+require "./db/seeds/space_owners/viken"
 viken = create_viken
 
 ## Space Type
 vgs = SpaceType.create(
-  type_name: 'VGS'
+  type_name: "VGS"
 )
 
 ## Rich text fields
@@ -26,17 +26,17 @@ i vest. Man kan leie begge samtidig, eller seperat.</p>'
 
 ## Full Space, without images
 frederikii_space = Space.create(
-  title: 'Frederik II',
-  address: 'Merkurveien 12',
-  post_number: '1613',
-  post_address: 'Fredrikstad',
+  title: "Frederik II",
+  address: "Merkurveien 12",
+  post_number: "1613",
+  post_address: "Fredrikstad",
   lat: 59.223840,
   lng: 10.925860,
   space_owner_id: viken.id,
   space_type_id: vgs.id,
-  organization_number: '974544466',
-  municipality_code: '3004',
-  fits_people: '1200',
+  organization_number: "974544466",
+  municipality_code: "3004",
+  fits_people: "1200",
   star_rating: 4.7,
   how_to_book: how_to_book,
   who_can_use: who_can_use,
@@ -45,7 +45,7 @@ frederikii_space = Space.create(
   more_info: more_info
 )
 
-require_relative '../reviews/reviews'
+require_relative "../reviews/reviews"
 demo_reviews_for_space(frederikii_space)
 
 ## Attach some sample images
@@ -57,7 +57,7 @@ images = %w[
   filename = File.basename(path)
   file = File.open(path)
   {
-    io: file, filename: filename, content_type: 'image/jpg'
+    io: file, filename: filename, content_type: "image/jpg"
   }
 end
 

--- a/db/seeds/spaces/gudeberg_no_info.rb
+++ b/db/seeds/spaces/gudeberg_no_info.rb
@@ -2,26 +2,26 @@
 
 ## Space Owner
 viken = SpaceOwner.create(
-  orgnr: '921693230'
+  orgnr: "921693230"
 )
 
 ## Space Type
 barne_og_ungdom = SpaceType.create(
-  type_name: '1. til 10.'
+  type_name: "1. til 10."
 )
 
 ## Empty Space, only info from NSR
 Space.create(
-  title: 'Gudeberg skole',
-  address: 'Nabbetorpveien 15',
-  post_number: '1632',
-  post_address: 'Gamle Fredrikstad',
+  title: "Gudeberg skole",
+  address: "Nabbetorpveien 15",
+  post_number: "1632",
+  post_address: "Gamle Fredrikstad",
   lat: 59.205250,
   lng: 10.962680,
   space_owner_id: viken.id,
   space_type_id: barne_og_ungdom.id,
-  organization_number: '974766337',
-  municipality_code: '3004',
+  organization_number: "974766337",
+  municipality_code: "3004",
   fits_people: nil,
   star_rating: nil
 )

--- a/db/seeds/spaces/nabbetorp_no_booking.rb
+++ b/db/seeds/spaces/nabbetorp_no_booking.rb
@@ -2,12 +2,12 @@
 
 ## Space Owner
 viken = SpaceOwner.create(
-  orgnr: '921693230'
+  orgnr: "921693230"
 )
 
 ## Space Type
 barneskole = SpaceType.create(
-  type_name: '1. til 7.'
+  type_name: "1. til 7."
 )
 
 ## Rich text fields
@@ -17,16 +17,16 @@ lån. De ønsker ikke bli kontaktet.</p>'
 
 ## Create space
 Space.create(
-  title: 'Nabbetorp spesialskole',
-  address: 'Enggata 76',
-  post_number: '1636',
-  post_address: 'Gamle Fredrikstad',
+  title: "Nabbetorp spesialskole",
+  address: "Enggata 76",
+  post_number: "1636",
+  post_address: "Gamle Fredrikstad",
   lat: 59.213868,
   lng: 10.972267,
   space_owner_id: viken.id,
   space_type_id: barneskole.id,
-  organization_number: '974766337',
-  municipality_code: '3004',
+  organization_number: "974766337",
+  municipality_code: "3004",
   fits_people: nil,
   star_rating: nil,
   how_to_book: how_to_book

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -4,6 +4,6 @@ Fabricator(:user) do
   first_name { Faker::Superhero.prefix + Faker::Superhero.descriptor }
   last_name { Faker::Superhero.suffix }
   email { Faker::Internet.email }
-  password 'password'
-  password_confirmation 'password'
+  password "password"
+  password_confirmation "password"
 end

--- a/spec/models/facility_category_spec.rb
+++ b/spec/models/facility_category_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe FacilityCategory, type: :model do
-  it 'can create a facility category' do
+  it "can create a facility category" do
     expect(Fabricate(:facility_category)).to be_truthy
   end
 end

--- a/spec/models/facility_review_spec.rb
+++ b/spec/models/facility_review_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe FacilityReview, type: :model do
-  it 'can generate an review' do
+  it "can generate an review" do
     expect(Fabricate(:facility_review)).to be_truthy
   end
 end

--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Facility, type: :model do
-  it 'can create a facility' do
+  it "can create a facility" do
     expect(Fabricate(:facility)).to be_truthy
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Review, type: :model do
-  it 'can add a review' do
+  it "can add a review" do
     review = Fabricate(:review)
     Fabricate(:facility_review, review: review)
     expect(review.title).to be_truthy
@@ -15,7 +15,7 @@ RSpec.describe Review, type: :model do
     expect(review.facility_reviews.count).to be 1
   end
 
-  it 'sets stars and facility_reviews for a Space when adding and removing a review' do
+  it "sets stars and facility_reviews for a Space when adding and removing a review" do
     space = Fabricate(:space)
     review = Fabricate(:review, space: space)
     facility = Fabricate(:facility)
@@ -30,18 +30,18 @@ RSpec.describe Review, type: :model do
     space.reload
 
     expect(space.star_rating).to eq(review.star_rating)
-    expect(space.reviews_for_facility(facility)).to eq('unlikely')
+    expect(space.reviews_for_facility(facility)).to eq("unlikely")
 
     review.destroy
     space.reload
 
     expect(space.star_rating).to be_nil
-    expect(space.reviews_for_facility(facility)).to eq('unknown')
+    expect(space.reviews_for_facility(facility)).to eq("unknown")
     expect { review.reload }.to raise_error(ActiveRecord::RecordNotFound)
     expect { facility_review.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
-  it 'can create a review' do
+  it "can create a review" do
     expect(Fabricate(:review)).to be_truthy
   end
 end

--- a/spec/models/space_owner_spec.rb
+++ b/spec/models/space_owner_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe SpaceOwner, type: :model do
-  it 'can create a spaceOwner' do
+  it "can create a spaceOwner" do
     expect(Fabricate(:space_owner)).to be_truthy
   end
 end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Space, type: :model do
-  it 'can create a space' do
+  it "can create a space" do
     expect(Fabricate(:space)).to be_truthy
   end
 
-  describe 'filter on factilites' do
+  describe "filter on factilites" do
     subject(:filter_subject) { described_class.filter_on_facilities(described_class.all, facilities) }
 
     let(:space1) { Fabricate(:space) }
     let(:space2) { Fabricate(:space) }
-    let(:kitchen) { Fabricate(:facility, title: 'kitchen') }
-    let(:toilet) { Fabricate(:facility, title: 'toilet') }
-    let(:shower) { Fabricate(:facility, title: 'shower') }
+    let(:kitchen) { Fabricate(:facility, title: "kitchen") }
+    let(:toilet) { Fabricate(:facility, title: "toilet") }
+    let(:shower) { Fabricate(:facility, title: "shower") }
 
     before do
       review_space1 = Fabricate(:review, space: space1)
@@ -30,41 +30,41 @@ RSpec.describe Space, type: :model do
       Fabricate(:facility_review, space: space2, review: review_space2, facility: toilet)
     end
 
-    context 'with kitchen' do
+    context "with kitchen" do
       let(:facilities) { [kitchen.id] }
 
-      it 'when both spaces have kitchen' do
+      it "when both spaces have kitchen" do
         expect(filter_subject.count).to eq(2)
       end
     end
 
-    context 'with toilet' do
+    context "with toilet" do
       let(:facilities) { [toilet.id] }
 
-      it 'when only one space have toilet' do
+      it "when only one space have toilet" do
         expect(filter_subject.count).to eq(2)
       end
     end
 
-    context 'with kitchen & toilet' do
+    context "with kitchen & toilet" do
       let(:facilities) { [kitchen.id, toilet.id] }
 
-      it 'when both spaces has either kitchen or toilet' do
+      it "when both spaces has either kitchen or toilet" do
         expect(filter_subject.count).to eq(2)
       end
 
-      it 'with correct order' do
+      it "with correct order" do
         expect(filter_subject.first).to eq(space2)
       end
     end
   end
 
-  describe 'filter on space types' do
+  describe "filter on space types" do
     subject { described_class.filter_on_space_types(space_types).count }
 
-    let(:space_type_a) { Fabricate(:space_type, type_name: 'A') }
-    let(:space_type_b) { Fabricate(:space_type, type_name: 'B') }
-    let(:space_type_c) { Fabricate(:space_type, type_name: 'C') }
+    let(:space_type_a) { Fabricate(:space_type, type_name: "A") }
+    let(:space_type_b) { Fabricate(:space_type, type_name: "B") }
+    let(:space_type_c) { Fabricate(:space_type, type_name: "C") }
 
     before do
       Fabricate(:space, space_type: space_type_b)
@@ -72,39 +72,39 @@ RSpec.describe Space, type: :model do
       Fabricate(:space, space_type: space_type_a)
     end
 
-    context 'when only type A' do
+    context "when only type A" do
       let(:space_types) { [space_type_a.id] }
 
       it { is_expected.to eq(1) }
     end
 
-    context 'when only type B' do
+    context "when only type B" do
       let(:space_types) { [space_type_b.id] }
 
       it { is_expected.to eq(2) }
     end
 
-    context 'when type A and B' do
+    context "when type A and B" do
       let(:space_types) { [space_type_a.id, space_type_b.id] }
 
       it { is_expected.to eq(3) }
     end
 
-    context 'when type C none' do
+    context "when type C none" do
       let(:space_types) { [space_type_c.id] }
 
       it { is_expected.to be_zero }
     end
   end
 
-  describe 'paper trails for space' do
+  describe "paper trails for space" do
     let(:space) { Fabricate(:space) }
 
-    it 'when changing field, create a new version' do
+    it "when changing field, create a new version" do
       expect(space.versions.count).to eq(1)
-      space.update(title: 'Hello World')
+      space.update(title: "Hello World")
       expect(space.versions.count).to eq(2)
-      expect(space.versions.last.event).to eq('update')
+      expect(space.versions.last.event).to eq("update")
     end
   end
 end

--- a/spec/models/space_type_spec.rb
+++ b/spec/models/space_type_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe SpaceType, type: :model do
-  it 'can create a spaceType' do
+  it "can create a spaceType" do
     expect(Fabricate(:space_type)).to be_truthy
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
-  it 'can create a user' do
+  it "can create a user" do
     expect(Fabricate(:user)).to be_truthy
   end
 end

--- a/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
+++ b/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Spaces::AggregateFacilityReviewsService do
   let(:space) { Fabricate(:space) }
@@ -11,53 +11,53 @@ RSpec.describe Spaces::AggregateFacilityReviewsService do
     Fabricate(:facility_review, space: space, experience: experience, facility: other_facility || facility)
   end
 
-  it 'turns into maybe if there are mixed reviews' do
+  it "turns into maybe if there are mixed reviews" do
     experience :was_allowed
     experience :was_not_allowed
-    expect(space.reload.reviews_for_facility(facility)).to eq('maybe')
+    expect(space.reload.reviews_for_facility(facility)).to eq("maybe")
   end
 
-  it 'turns into likely if there are over 2/3 positive reviews' do
+  it "turns into likely if there are over 2/3 positive reviews" do
     experience :was_not_allowed
     3.times { experience :was_allowed }
-    expect(space.reload.reviews_for_facility(facility)).to eq('likely')
+    expect(space.reload.reviews_for_facility(facility)).to eq("likely")
   end
 
-  it 'turns into likely if there are over 2/3 positive reviews, even if those are only the last five' do
+  it "turns into likely if there are over 2/3 positive reviews, even if those are only the last five" do
     10.times { experience :was_not_allowed }
     4.times { experience :was_allowed }
-    expect(space.reload.reviews_for_facility(facility)).to eq('likely')
+    expect(space.reload.reviews_for_facility(facility)).to eq("likely")
   end
 
-  it 'turns into impossible if half or more say it does not exist' do
+  it "turns into impossible if half or more say it does not exist" do
     experience :was_not_allowed
     experience :was_not_available
-    expect(space.reload.reviews_for_facility(facility)).to eq('impossible')
+    expect(space.reload.reviews_for_facility(facility)).to eq("impossible")
   end
 
-  it 'turns into unlikely if there are over 2/3 negative reviews' do
+  it "turns into unlikely if there are over 2/3 negative reviews" do
     experience :was_allowed
     2.times { experience :was_not_allowed }
-    expect(space.reload.reviews_for_facility(facility)).to eq('unlikely')
+    expect(space.reload.reviews_for_facility(facility)).to eq("unlikely")
   end
 
-  it 'Is unknown if no reviews, and turns back into unknown if all facility reviews are deleted' do
+  it "Is unknown if no reviews, and turns back into unknown if all facility reviews are deleted" do
     facility # ensure that the facility object is made
     space.facility_reviews.destroy_all
-    expect(space.reload.aggregated_facility_reviews.first.experience).to eq('unknown')
+    expect(space.reload.aggregated_facility_reviews.first.experience).to eq("unknown")
 
     2.times { experience :was_not_allowed }
     space.facility_reviews.destroy_all
 
-    expect(space.reload.reviews_for_facility(facility)).to eq('unknown')
+    expect(space.reload.reviews_for_facility(facility)).to eq("unknown")
   end
 
-  it 'Works even if there are unrelated facilities and reviews' do
+  it "Works even if there are unrelated facilities and reviews" do
     experience :was_allowed
     experience :was_not_allowed
     2.times do
       experience :was_allowed, Fabricate(:facility)
     end
-    expect(space.reload.reviews_for_facility(facility)).to eq('maybe')
+    expect(space.reload.reviews_for_facility(facility)).to eq("maybe")
   end
 end

--- a/spec/services/spaces/aggregate_star_rating_service_spec.rb
+++ b/spec/services/spaces/aggregate_star_rating_service_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Spaces::AggregateStarRatingService do
   let(:space) { Fabricate(:space) }
 
-  it 'Rating is calculated by averaging all reviews' do
+  it "Rating is calculated by averaging all reviews" do
     Fabricate(:review, space: space, star_rating: 3)
     Fabricate(:review, space: space, star_rating: 5)
     Fabricate(:review, space: space, star_rating: 5)
@@ -14,7 +14,7 @@ RSpec.describe Spaces::AggregateStarRatingService do
     expect(space.reload.star_rating).to eq(4.3)
   end
 
-  it 'Rating equals nil if there are no reviews' do
+  it "Rating equals nil if there are no reviews" do
     Fabricate(:review, space: space, star_rating: 3)
     Fabricate(:review, space: space, star_rating: 5)
     space.reviews.destroy_all
@@ -22,7 +22,7 @@ RSpec.describe Spaces::AggregateStarRatingService do
     expect(space.reload.star_rating).to eq(nil)
   end
 
-  it 'Rating can be calculated even if there are reviews with nil stars' do
+  it "Rating can be calculated even if there are reviews with nil stars" do
     Fabricate(:review, space: space, star_rating: 3)
     Fabricate(:review, space: space, star_rating: 5)
     Fabricate(:review, space: space, star_rating: nil)

--- a/spec/services/spaces/location_search_service_spec.rb
+++ b/spec/services/spaces/location_search_service_spec.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Spaces::LocationSearchService do
-  it 'searches only on address' do
-    VCR.use_cassette('location_search_address') do
-      expect(described_class.call(address: 'Hammerstads gate 32').count).to eq(1)
+  it "searches only on address" do
+    VCR.use_cassette("location_search_address") do
+      expect(described_class.call(address: "Hammerstads gate 32").count).to eq(1)
     end
   end
 
-  it 'searches only on postcode' do
-    VCR.use_cassette('location_search_postcode') do
-      expect(described_class.call(post_number: 3060, post_address: 'svelvik').count).to eq(10)
+  it "searches only on postcode" do
+    VCR.use_cassette("location_search_postcode") do
+      expect(described_class.call(post_number: 3060, post_address: "svelvik").count).to eq(10)
     end
   end
 
-  it 'searches only on postaddress' do
-    VCR.use_cassette('location_search_postaddress') do
-      expect(described_class.call(post_address: 'svelvik').count).to eq(10)
+  it "searches only on postaddress" do
+    VCR.use_cassette("location_search_postaddress") do
+      expect(described_class.call(post_address: "svelvik").count).to eq(10)
     end
   end
 
-  it 'searches on address and postcode' do
-    VCR.use_cassette('location_search_address_postcode') do
-      expect(described_class.call(address: 'Ankerveien 2', post_number: 3060).count).to eq(1)
+  it "searches on address and postcode" do
+    VCR.use_cassette("location_search_address_postcode") do
+      expect(described_class.call(address: "Ankerveien 2", post_number: 3060).count).to eq(1)
     end
   end
 end

--- a/spec/views/facilities/index.html.erb_spec.rb
+++ b/spec/views/facilities/index.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'facilities/index.html.erb', type: :view do
+RSpec.describe "facilities/index.html.erb", type: :view do
   let(:facilities) { Fabricate.times(3, :facility) }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:facilities, facilities)
     assign(:facilty, Facility.new)
     render

--- a/spec/views/facilities/show.html.erb_spec.rb
+++ b/spec/views/facilities/show.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'facilities/show.html.erb', type: :view do
+RSpec.describe "facilities/show.html.erb", type: :view do
   let(:facility) { Fabricate :facility }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:facility, facility)
     render
 

--- a/spec/views/reviews/edit.html.erb_spec.rb
+++ b/spec/views/reviews/edit.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'reviews/edit', type: :view do
+RSpec.describe "reviews/edit", type: :view do
   let(:review) { Fabricate :review }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:review, review)
     render
 

--- a/spec/views/reviews/index.html.erb_spec.rb
+++ b/spec/views/reviews/index.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'reviews/index.html.erb', type: :view do
+RSpec.describe "reviews/index.html.erb", type: :view do
   let(:reviews) { Fabricate.times(3, :review) }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:reviews, reviews)
     render
 

--- a/spec/views/reviews/show.html.erb_spec.rb
+++ b/spec/views/reviews/show.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'reviews/show.html.erb', type: :view do
+RSpec.describe "reviews/show.html.erb", type: :view do
   let(:review) { Fabricate :review }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:review, review)
     render
 

--- a/spec/views/space_owners/edit.html.erb_spec.rb
+++ b/spec/views/space_owners/edit.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'space_owners/edit', type: :view do
+RSpec.describe "space_owners/edit", type: :view do
   let(:space_owner) { Fabricate :space_owner }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:space_owner, space_owner)
     render
 

--- a/spec/views/space_owners/index.html.erb_spec.rb
+++ b/spec/views/space_owners/index.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'space_owners/index.html.erb', type: :view do
+RSpec.describe "space_owners/index.html.erb", type: :view do
   let(:space_owners) { Fabricate.times(3, :space_owner) }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:space_owners, space_owners)
     render
 

--- a/spec/views/space_owners/show.html.erb_spec.rb
+++ b/spec/views/space_owners/show.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'space_owners/show', type: :view do
+RSpec.describe "space_owners/show", type: :view do
   let(:space_owner) { Fabricate :space_owner }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:space_owner, space_owner)
     render
 

--- a/spec/views/spaces/edit.html.erb_spec.rb
+++ b/spec/views/spaces/edit.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'spaces/edit', type: :view do
+RSpec.describe "spaces/edit", type: :view do
   let(:space) { Fabricate :space }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:space, space)
     render
 

--- a/spec/views/spaces/index.html.erb_spec.rb
+++ b/spec/views/spaces/index.html.erb_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'spaces/index.html.erb', type: :view do
-  it 'renders the page' do
+RSpec.describe "spaces/index.html.erb", type: :view do
+  it "renders the page" do
     assign(:space, Space.new)
 
     render

--- a/spec/views/spaces/show.html.erb_spec.rb
+++ b/spec/views/spaces/show.html.erb_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'spaces/show', type: :view do
-  let(:space) { Fabricate :space, title: 'Space Title' }
+RSpec.describe "spaces/show", type: :view do
+  let(:space) { Fabricate :space, title: "Space Title" }
 
-  it 'renders the page' do
+  it "renders the page" do
     assign(:space, space)
     render
 


### PR DESCRIPTION
Feel free to dismiss this one, but I've found it annoying to switch between "" and '' for strings when I have to add or remove string literals, and so think this will help improve DX and productivity.