### PR TITLE
Fix bug where Space#update was blocked when address wasn't changed

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -108,7 +108,7 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
       address: params[:space][:address],
       post_number: params[:space][:post_number],
       post_address: params[:space][:post_address]
-    )
+    ) || {}
   end
 
   def filter_spaces(params)


### PR DESCRIPTION
https://trello.com/c/m3NlBbrm/131-spaceupdate-d%C3%B8r-pga-hash-feil

Buggen ga feilmelding: 

```
TypeError (no implicit conversion of nil into Hash):
  
app/controllers/spaces_controller.rb:51:in `update'

```

Som gjaldt denne kodesnutten: 

```ruby
 if @space.update(
      **space_params,
      **address_params
    )
```

Ved å sørge for at address_params alltid er en hash så løste det seg. 