### PR TITLE
Add default url option to production as env variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,5 +10,10 @@
     {
       "plan": "heroku-postgresql"
     }
-  ]
+  ],
+  "env": {
+    "HEROKU_APP_NAME": {
+      "required": true
+    }
+  }
 }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,7 +102,8 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  Rails.application.routes.default_url_options[:host] = ENV["HOST"]
+  Rails.application.routes.default_url_options[:host] =
+    ENV["DEFAULT_HOST"] || "#{ENV.fetch('HEROKU_APP_NAME')}.herokuapp.com"
 
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,8 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  Rails.application.routes.default_url_options[:host] = ENV["HOST"]
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
This is required for sendgrid to work, will not work on the review apps as they don't have the ENV["HOST"] set 