### PR TITLE
Import data from NSR through seed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "devise", "~> 4.8"
 
 gem "activerecord-import"
+gem "addressable"
 gem "diffy"
 gem "gravtastic"
 gem "hotwire-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 gem "devise", "~> 4.8"
 
+gem "activerecord-import"
 gem "diffy"
 gem "gravtastic"
 gem "hotwire-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,6 +405,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
+  addressable
   bootsnap (>= 1.4.4)
   bullet
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     activerecord (6.1.4.1)
       activemodel (= 6.1.4.1)
       activesupport (= 6.1.4.1)
+    activerecord-import (1.2.0)
+      activerecord (>= 3.2)
     activestorage (6.1.4.1)
       actionpack (= 6.1.4.1)
       activejob (= 6.1.4.1)
@@ -402,6 +404,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-import
   bootsnap (>= 1.4.4)
   bullet
   byebug

--- a/app/helpers/parse_url_helper.rb
+++ b/app/helpers/parse_url_helper.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-require "uri"
-
 module ParseUrlHelper
   def parse_url
-    uri = URI.parse(url)
-    self.url = "http://#{uri}" unless uri.scheme || url.blank?
+    uri = Addressable::URI.parse(url)
+    self.url = "http://#{url}" unless uri.blank? || uri.scheme || url.blank?
   end
 end

--- a/db/seeds/imports/nsr/helpers.rb
+++ b/db/seeds/imports/nsr/helpers.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# rubocop:disable all
+
+def filter_schools(schools)
+  foul_titles = [
+    /voksenopplæring/i,
+    /vikarer/i,
+    /fellestjeneste/i
+  ]
+  # Remove any schools we do not care for
+  schools.reject! do |school|
+    foul_titles.any? { |pattern| pattern.match? get_info(school["title"]) }
+  end
+end
+
+def get_meta(school, field)
+  fields = {}
+  school["meta"].each do |item|
+    fields = fields.merge get_info(item)
+  end
+  fields[field]
+end
+
+def get_info(info)
+  return info["info"] if info["info"]
+
+  info
+end
+
+def knead_title(title)
+  title.sub! /vid.regå.nde sk.le/i, "VGS"
+  title.sub! /vid.regå.nde privatsk.le/i, "privat VGS"
+  title.sub! /vid.regå.nde/i, "VGS"
+  title
+end
+
+def space_from(school)
+  space_owner = SpaceOwner.find_by space_owner_from(school)
+  space_type = SpaceType.find_by(space_types_from(school))
+  {
+    title: knead_title(get_info(school["title"])),
+    address: school["address"]["street"],
+    post_number: school["address"]["postnumber"],
+    post_address: school["address"]["poststed"],
+    lat: school["lat"],
+    lng: school["lon"],
+    municipality_code: school["kommuneNummer"],
+    organization_number: get_meta(school, "organizationalNumber"),
+    fits_people: get_meta(school, "pupils"),
+    space_owner: space_owner,
+    space_type: space_type
+  }
+end
+
+def space_types_from(school)
+  # TODO: Make it possible to have several space types.
+  { type_name: get_meta(school, "types")[0] }
+end
+
+def space_owner_from(school)
+  # TODO: Change Space model so SpaceOwner is OPTIONAL. Not all spaces have a space owner that's relevant to list out.
+  return unless school && school["owner"]
+
+  owner = get_info(school["owner"])
+  {
+    orgnr: owner["organizationNumber"],
+    title: owner["title"]
+  }
+end
+
+def add_space_contacts_from(school, space)
+  contacts = school["contacts"].map { |contact| get_info contact }
+  contacts.filter! { |contact| contact[:email] || contact[:phone] || contact[:url] }
+  contacts.filter! { |contact| contact[:role] || contact[:name] || contact[:url] }
+  contacts_parsed = contacts.map do |contact|
+    parsed = {
+      title: "#{contact[:role]} #{contact[:name]}".strip
+    }
+    parsed["url"] = contact["url"] if contact["url"]&.present?
+    parsed["email"] = contact["email"] if contact["email"]&.present?
+    parsed["telephone"] = contact["phone"] if contact["phone"]&.present?
+  end
+  space.space_contacts.build contacts_parsed
+  space
+end
+
+def new_unless_exists(model, item)
+  model.new(item) unless model.find_by(item)
+end
+
+def new_all_unless_exists(model, items)
+  new_items = items.reject { |item| model.find_by(item) }
+  new_items.map { |item| model.new item }
+end
+
+# rubocop:enable all

--- a/db/seeds/imports/nsr/import_function.rb
+++ b/db/seeds/imports/nsr/import_function.rb
@@ -53,8 +53,10 @@ def import_spaces_from_nsr_schools
 
     space_contacts_from(school).each do |contact|
       space_contact = new_unless_exists SpaceContact, contact
-      space_contact.space = Space.find_by space_from(school) if space_contact
-      space_contacts << space_contact if space_contact
+      if space_contact
+        space_contact.space = space || Space.find_by(space_from(school))
+        space_contacts << space_contact if space_contact
+      end
     end
   end
   # Save them all with import

--- a/db/seeds/imports/nsr/import_function.rb
+++ b/db/seeds/imports/nsr/import_function.rb
@@ -46,8 +46,9 @@ def import_spaces_from_nsr_schools
   # Then start parsing Spaces, as they depend on the above
   spaces = []
   space_contacts = []
-  p "Parsing spaces and space contacts"
-  data.each do |school|
+  data.each_with_index do |school, index|
+    print "\rParsing spaces and space contacts from nsr school data: #{index} / #{data.length}"
+
     space = new_unless_exists Space, space_from(school)
     spaces << space if space
 
@@ -60,17 +61,18 @@ def import_spaces_from_nsr_schools
     end
   end
   # Save them all with import
-  p "importing #{spaces.length} spaces"
+  p "\nimporting #{spaces.length} spaces"
   Space.import(spaces)
 
-  p "Aggregating facility reviews for spaces (takes a minute)"
-  spaces.each do |space|
+  spaces.each_with_index do |space, index|
+    print "\rAdding unknown aggregated facility reviews for spaces #{index} / #{spaces.length}"
+
     Facility.all.order(:created_at).map do |facility|
       AggregatedFacilityReview.create!(experience: "unknown", space: space, facility: facility)
     end
   end
 
-  p "importing #{space_contacts.length} space contacts"
+  p "\nimporting #{space_contacts.length} space contacts"
   SpaceContact.import(space_contacts)
 
 

--- a/db/seeds/imports/nsr/import_function.rb
+++ b/db/seeds/imports/nsr/import_function.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# rubocop:disable all
+
+require "json"
+require "set"
+require "./db/seeds/imports/nsr/helpers"
+
+def import_spaces_from_nsr_schools
+  # Counts
+  p({
+      info: "In db before import from NSR:",
+      spaces: Space.count,
+      space_types: SpaceType.count,
+      space_owners: SpaceOwner.count,
+      space_contacts: SpaceContact.count
+    })
+
+  # Load json file
+  file = File.read(Rails.root.join("db", "seeds", "imports", "nsr", "nsrParsedSchools.json"))
+  data = filter_schools(JSON.parse(file))
+
+  p raw_schools_to_parse: data.length
+
+  # Set up and save SpaceTypes
+  space_types = [
+    { type_name: "barneskole" },
+    { type_name: "ungdomsskole" },
+    { type_name: "grunnskole" },
+    { type_name: "vgs" }
+  ]
+  SpaceType.import new_all_unless_exists(SpaceType, space_types)
+
+  # Trawl through it, and extract information into Rails format
+
+  # Set up owners first:
+  space_owners = Set[]
+  data.each do |school|
+    space_owners << space_owner_from(school)
+  end
+  # Save them
+  SpaceOwner.import new_all_unless_exists(SpaceOwner, space_owners)
+
+  # Then start parsing Spaces, as they depend on the above
+  spaces = []
+  data.each do |school|
+    space = new_unless_exists Space, space_from(school)
+    next unless space
+
+    space = add_space_contacts_from(school, space)
+    spaces << space
+  end
+  # Save them all with import
+  Space.import spaces, recursive: true
+
+  p({
+      info: "To import from NSR JSON:",
+      spaces: spaces.length,
+      space_types: space_types.length,
+      space_owners: space_owners.length
+    })
+  p({
+      info: "In db after import from NSR:",
+      spaces: Space.count,
+      space_types: SpaceType.count,
+      space_owners: SpaceOwner.count,
+      space_contacts: SpaceContact.count
+    })
+end
+
+# rubocop:enable all

--- a/db/seeds/imports/nsr/import_function.rb
+++ b/db/seeds/imports/nsr/import_function.rb
@@ -63,6 +63,13 @@ def import_spaces_from_nsr_schools
   p "importing #{spaces.length} spaces"
   Space.import(spaces)
 
+  p "Aggregating facility reviews for spaces (takes a minute)"
+  spaces.each do |space|
+    Facility.all.order(:created_at).map do |facility|
+      AggregatedFacilityReview.create!(experience: "unknown", space: space, facility: facility)
+    end
+  end
+
   p "importing #{space_contacts.length} space contacts"
   SpaceContact.import(space_contacts)
 

--- a/db/seeds/imports/nsr/readme.md
+++ b/db/seeds/imports/nsr/readme.md
@@ -1,0 +1,9 @@
+# NSR
+
+NSR (Nasjonalt skoleregister). Parses data fetched from the Norwegian national registry for schools, and parses it to Rails.
+
+Data is fetched using the NSR script in [lnu-norge/experiments](https://github.com/lnu-norge/experiments/).
+
+Specifically the ones in https://github.com/lnu-norge/experiments/tree/master/space-aggregator/fetchingData
+
+You can read more about it in the readme there: https://github.com/lnu-norge/experiments/blob/master/space-aggregator/fetchingData/src/dataSources/Data%20Source%20README.md

--- a/db/seeds/nsr.rb
+++ b/db/seeds/nsr.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "./db/seeds/imports/nsr/import_function"
+
+import_spaces_from_nsr_schools


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14905290/142191191-d19b8dbc-58fa-41c8-b8b4-a0b81f4e2546.png)

Imports schools from NSR, and adds them. Tries not to duplicate things.

To run the import, set the flag SEED_FILE to nsr before running seed (or reset):

```bash
SEED_FILE=nsr rails db:seed
```

## To do

- [x] Get Spaces imported
- [x] Get SpaceTypes imported
- [x] Get SpaceOwners imported
- [x] Filter out unwanted spaces
- [x] Get SpaceContacts imported correctly
- [x] Fikse så SpaceContacts importeres på first pass, og ikke må vente til gang 2
- [x] Skaffe lat lng på ny for spaces med lat-lng på 0,0, og fjerne dem om vi ikke finner en
- [x] Kjøre aggregate reviews for alle spaces, så det er i orden for søk og filter og sånn

## Not done: 
- [ ] Make sure the previous seeds and dev imports match the new SpaceTypes and Spaces.
(Can be it's own PR and card)