### PR TITLE
Facilities listing in search

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -101,9 +101,13 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
       }
     end
 
+    facility_ids = params[:facilities]&.map(&:to_i) || []
     render json: {
       listing: render_to_string(
-        partial: "spaces/index/space_listings", locals: { spaces: spaces.first(10) }
+        partial: "spaces/index/space_listings", locals: {
+          spaces: spaces.first(10),
+          filtered_facilities: Facility.find(facility_ids)
+        }
       ),
       markers: markers
     }

--- a/app/javascript/controllers/mapbox_controller.js
+++ b/app/javascript/controllers/mapbox_controller.js
@@ -134,12 +134,12 @@ export default class extends Controller {
     const southEast = this.map.getBounds().getSouthEast();
 
     const facilitiesString = this.facilityTargets.map(t =>
-      t.checked ? `facilities[]=${t.name}&` : ''
-    );
+      t.checked ? `facilities[]=${encodeURIComponent(t.name)}&` : ''
+    ).join('');
 
     const spaceTypesString = this.spaceTypeTargets.map(t =>
-      t.checked ? `space_types[]=${t.name}&` : ''
-    );
+      t.checked ? `space_types[]=${encodeURIComponent(t.name)}&` : ''
+    ).join('');
 
     return [
       '/spaces_search?',

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |msg_type, message| %>
-  <div data-controller="flash" data-flash-target="flash" aria-live=<%= msg_type == "notice" ? "polite" : "assertive" %> class="flash z-100 opacity-0">
+  <div data-controller="flash" data-flash-target="flash" aria-live="<%= msg_type == "notice" ? "polite" : "assertive" %>" class="flash z-100 opacity-0">
     <div class="w-full flex flex-col items-center space-y-4 sm:items-end">
       <div class="max-w-sm w-full bg-white shadow-lg rounded-lg pointer-events-auto ring-1 ring-black ring-opacity-5 overflow-hidden">
         <div class="p-4">

--- a/app/views/spaces/index/_space_facility_listing.html.erb
+++ b/app/views/spaces/index/_space_facility_listing.html.erb
@@ -1,6 +1,5 @@
 <ul class="grid grid-cols-2 gap-2 mt-2">
-  <% filtered_facilities.each do |filtered_facility| %>
-    <% facility = filtered_facility %>
+  <% filtered_facilities.each do |facility| %>
     <% review = space.reviews_for_facility(facility) %>
     <%= render partial: 'spaces/show/facility_item', locals: {
       icon: facility[:icon],

--- a/app/views/spaces/index/_space_facility_listing.html.erb
+++ b/app/views/spaces/index/_space_facility_listing.html.erb
@@ -1,0 +1,12 @@
+<ul class="grid grid-cols-2 gap-2 mt-2">
+  <% filtered_facilities.each do |filtered_facility| %>
+    <% facility = filtered_facility %>
+    <% review = space.reviews_for_facility(facility) %>
+    <%= render partial: 'spaces/show/facility_item', locals: {
+      icon: facility[:icon],
+      title: facility[:title],
+      review: review,
+      tooltip: t("tooltips.facility_aggregated_experience.#{review}")
+    } %>
+  <% end %>
+</ul>

--- a/app/views/spaces/index/_space_listing.html.erb
+++ b/app/views/spaces/index/_space_listing.html.erb
@@ -56,6 +56,10 @@ TODO:
 
     <!-- Filtered facilites listing -->
 
+    <% filtered_facilities.each do |facility| %>
+      <%= facility.title %>
+    <% end %>
+
     <ul class="grid grid-cols-2 gap-2 mt-2">
       <li class="flex items-center gap-1.5" title="Sannsynlig! Andre har fått lov">
         Overnatting

--- a/app/views/spaces/index/_space_listing.html.erb
+++ b/app/views/spaces/index/_space_listing.html.erb
@@ -56,41 +56,7 @@ TODO:
 
     <!-- Filtered facilites listing -->
 
-    <% filtered_facilities.each do |facility| %>
-      <%= facility.title %>
-    <% end %>
+    <%= render partial: 'spaces/index/space_facility_listing', locals: { space: space, filtered_facilities: filtered_facilities } if filtered_facilities  %>
 
-    <ul class="grid grid-cols-2 gap-2 mt-2">
-      <li class="flex items-center gap-1.5" title="Sannsynlig! Andre har fått lov">
-        Overnatting
-        <span>
-           <%= inline_svg_tag 'facility_status/likely' %>
-        </span>
-      </li>
-      <li class="flex items-center gap-1.5"  title="Usannsynlig: Ingen eller få har fått lov">
-        Kjøkken
-        <span>
-           <%= inline_svg_tag 'facility_status/unlikely' %>
-        </span>
-      </li>
-      <li class="flex items-center gap-1.5" title="Kanskje: Ikke alle får lov">
-        Dansegulv
-        <span>
-           <%= inline_svg_tag 'facility_status/maybe' %>
-        </span>
-      </li>
-      <li class="flex items-center gap-1.5" title="Usikkert: Ingen har spurt om lydanlegg">
-        Lydanlegg
-        <span>
-           <%= inline_svg_tag 'facility_status/unknown' %>
-        </span>
-      </li>
-      <li class="flex items-center gap-1.5" title="Umulig: Frederik II har ikke flyplass">
-        Flyplass
-        <span>
-           <%= inline_svg_tag 'facility_status/impossible' %>
-        </span>
-      </li>
-    </ul>
   </div>
 <% end %>

--- a/app/views/spaces/index/_space_listings.html.erb
+++ b/app/views/spaces/index/_space_listings.html.erb
@@ -1,4 +1,4 @@
 <%= t('space_listing.no_results') if spaces.empty? %>
 <% spaces.each do |space| %>
-  <%= render partial: "spaces/index/space_listing", locals: { space: space } %>
+  <%= render partial: "spaces/index/space_listing", locals: { space: space, filtered_facilities: filtered_facilities } %>
 <% end %>


### PR DESCRIPTION
Makes sure the list of spaces show which of the filtered facilities it matches.

![image](https://user-images.githubusercontent.com/14905290/142426062-39da017c-8855-4231-8f5a-198c399ee6db.png)

Also fixes some bugs in the filter, where no filters other than Overnatting could be set.

Exposes a new bug in the NSR imports, which is that we haven't run aggregated search and therefore have nil values for all experiences. Added a comment to that one in the relevant PR.