### PR TITLE
Add search count to search index

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -95,7 +95,9 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
   end
 
   def spaces_search
-    spaces = filter_spaces(params).first(20)
+    filtered_spaces = filter_spaces(params)
+    space_count = filtered_spaces.count
+    spaces = filtered_spaces.first(SPACE_SEARCH_PAGE_SIZE)
 
     markers = spaces.map do |space|
       html = render_to_string partial: "spaces/index/map_marker", locals: { space: space }
@@ -111,8 +113,10 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
     render json: {
       listing: render_to_string(
         partial: "spaces/index/space_listings", locals: {
-          spaces: spaces.first(10),
-          filtered_facilities: Facility.find(facility_ids)
+          spaces: spaces,
+          filtered_facilities: Facility.find(facility_ids),
+          space_count: space_count,
+          page_size: SPACE_SEARCH_PAGE_SIZE
         }
       ),
       markers: markers
@@ -120,6 +124,8 @@ class SpacesController < AuthenticateController # rubocop:disable Metrics/ClassL
   end
 
   private
+
+  SPACE_SEARCH_PAGE_SIZE = 20
 
   def get_address_params(params)
     Space.search_for_address(

--- a/app/views/spaces/index.html.erb
+++ b/app/views/spaces/index.html.erb
@@ -6,7 +6,6 @@
     </div>
     <div class="md:overflow-y-auto md:w-md md:h-full">
       <%= render partial: 'spaces/index/filter_button' %>
-      <%= render partial: 'spaces/index/space_listing_header' %>
       <div id="space-listing" class="px-4">
       </div>
     </div>

--- a/app/views/spaces/index/_space_listing_header.html.erb
+++ b/app/views/spaces/index/_space_listing_header.html.erb
@@ -1,5 +1,5 @@
-<div class="flex px-4  pt-4">
-  <h1 class="text-2xl mt-1"><%= Space.model_name.human(count: 2) %></h1>
+<div class="flex">
+  <h1 class="text-2xl mt-1"><%= t('space_filter.spaces_that_might_work', count: space_count ) %></h1>
   <%= link_to new_space_path, class: 'ml-2 unstyled-link edit-button collapsable' do %>
           <span class="text">
             <%= t('space_listing.new_space') %>

--- a/app/views/spaces/index/_space_listings.html.erb
+++ b/app/views/spaces/index/_space_listings.html.erb
@@ -1,4 +1,15 @@
+<%= render partial: 'spaces/index/space_listing_header', locals: { space_count: space_count } %>
 <%= t('space_listing.no_results') if spaces.empty? %>
 <% spaces.each do |space| %>
   <%= render partial: "spaces/index/space_listing", locals: { space: space, filtered_facilities: filtered_facilities } %>
+<% end %>
+<% if space_count > page_size %>
+  <div class="content">
+    <hr />
+    <p class="text-gray-700 italic">
+      <%= t('space_filter.showing_only_page_size_spaces', count: page_size) %>
+      <%= t('space_filter.filter_or_zoom') %>
+    </p>
+    <hr />
+  </div>
 <% end %>

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -44,6 +44,13 @@ nb:
     show_spaces:
       one: 'Vis ett lokale'
       other: 'Vis %{count} lokaler'
+    showing_only_page_size_spaces:
+      one: 'Viser kun ett lokale av gangen.'
+      other: 'Viser kun %{count} lokaler av gangen.'
+    filter_or_zoom: "Filtrér eller zoom inn for å se andre."
+    spaces_that_might_work:
+      one: "Ett lokale kan passe:"
+      other: "%{count} lokaler kan passe:"
     edit_filter: 'Rediger filtre'
     location: 'Sted'
     more_filters: 'Flere filtre'

--- a/spec/views/spaces/index.html.erb_spec.rb
+++ b/spec/views/spaces/index.html.erb_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "spaces/index.html.erb", type: :view do
 
     render
 
-    expect(rendered).to match /h1/
+    expect(rendered).to match /space-listing/
     expect(rendered).to match /map-frame/
     # Cannot test that individual Spaces show up here since the render of them is triggered by Mapbox
   end


### PR DESCRIPTION
Depends on #93 and builds on that PR. Should not be merged until #93 is merged.  Temporarily set up to merge against #93 so it's easier to see what's new, and should not be merged until it's changed back to merge to main!

- [ ] Change to merge to main

# Changes

Adds counts to search, as in Figma sketch, and sets a page size default that is shared with the view.

![image](https://user-images.githubusercontent.com/14905290/142694664-3b8cad1f-9898-47d9-a865-e2f73efa6fd0.png)

Also adds a little placeholder footer if the search count is higher than the page size, that is - if content is hidden from view: 

![image](https://user-images.githubusercontent.com/14905290/142694758-943992d9-a261-4f8c-bc06-f7d89f1bb8c6.png)


In the future, we probably want pagination instead of this.