### PR TITLE
Make sure hovered map marker is on top of the other markers

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -2,13 +2,14 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+@import "./avatar";
 @import "./common_elements.scss";
 @import "./content.scss";
-@import "./editable.scss";
 @import "./devise.scss";
+@import "./editable.scss";
 @import "./flash.scss";
 @import "./horizontal_card";
-@import "./avatar";
+@import "./map";
 @import "./modal";
 @import "./star_picker";
 @import "./radio_slider";

--- a/app/javascript/stylesheets/map.scss
+++ b/app/javascript/stylesheets/map.scss
@@ -1,0 +1,5 @@
+// Custom CSS for mapbox map
+
+.mapboxgl-marker:hover {
+  z-index: 1;
+}


### PR DESCRIPTION
When hovering a map marker, it now is on top and is possible to read: 

![image](https://user-images.githubusercontent.com/14905290/142718694-a2184921-f763-4f06-bc85-482f60f5fcea.png)
