### PR TITLE
Add mac 21, as required by ruby 3.0.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
This was added by bundle install. Not sure if it should replace the line above or not.