### PR TITLE
Move aggregating of reviews to the Review model

### DIFF
--- a/app/models/facility_review.rb
+++ b/app/models/facility_review.rb
@@ -6,9 +6,6 @@ class FacilityReview < ApplicationRecord
   belongs_to :user
   belongs_to :review
 
-  after_save { space.aggregate_facility_reviews }
-  after_destroy { space.aggregate_facility_reviews }
-
   enum experience: { was_allowed: 0, was_not_allowed: 2, was_not_available: 3 }
 
   scope :impossible, -> { where(experience: :was_not_available) }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -28,6 +28,9 @@ class Review < ApplicationRecord
   validates :star_rating, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }, if: :been_there?
   validates :facility_reviews, presence: true, if: :only_contacted?
 
+  after_save { space.aggregate_facility_reviews }
+  after_destroy { space.aggregate_facility_reviews }
+
   after_save { space.aggregate_star_rating }
   after_destroy { space.aggregate_star_rating }
 

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Review, type: :model do
       experience: :was_not_allowed
     )
 
+    space.aggregate_facility_reviews
+
     space.reload
 
     expect(space.star_rating).to eq(review.star_rating)

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe Space, type: :model do
       Fabricate(:facility_review, space: space2, review: review_space2, facility: kitchen)
       Fabricate(:facility_review, space: space2, review: review_space2, facility: shower)
       Fabricate(:facility_review, space: space2, review: review_space2, facility: toilet)
+
+      space1.aggregate_facility_reviews
+      space2.aggregate_facility_reviews
     end
 
     context "with kitchen" do

--- a/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
+++ b/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Spaces::AggregateFacilityReviewsService do
 
   def experience(experience, other_facility = nil)
     Fabricate(:facility_review, space: space, experience: experience, facility: other_facility || facility)
+    space.reload.aggregate_facility_reviews
   end
 
   it "turns into maybe if there are mixed reviews" do
@@ -49,6 +50,8 @@ RSpec.describe Spaces::AggregateFacilityReviewsService do
 
     2.times { experience :was_not_allowed }
     space.facility_reviews.destroy_all
+
+    space.aggregate_facility_reviews
 
     expect(space.reload.reviews_for_facility(facility)).to eq("unknown")
   end


### PR DESCRIPTION
This changes when the aggregator is ran and results in a decrease from 2sec to 300ms to create a new review.

The old way would cause the aggregator to rerun for every facility review so it would run 13 times on when creating a review with our current facility setup.