### PR TITLE
Also hide the URL if it's just an empty string

### DIFF
--- a/app/views/spaces/show/_basics.html.erb
+++ b/app/views/spaces/show/_basics.html.erb
@@ -32,7 +32,7 @@
       <%= @space.post_address %>
       </span>
   </div>
-  <% unless @space.url.nil? %>
+  <% if @space.url.present? %>
     <div class="flex gap-2 mt-2">
       <%= inline_svg_tag 'url' %>
       <span>


### PR DESCRIPTION
Previously we would show the url like this, if it was saved as an empty string:

![image](https://user-images.githubusercontent.com/14905290/146332821-fd495934-7944-4696-a18d-6e6de7ebbab3.png)

Now it hides it if the string is not `.present?`

![image](https://user-images.githubusercontent.com/14905290/146332904-bca75417-5f5d-4b4d-924b-e76f13f10c91.png)
