### PR TITLE
Dropdown styling: Minor fixes

### DIFF
--- a/app/javascript/stylesheets/tom_select.scss
+++ b/app/javascript/stylesheets/tom_select.scss
@@ -188,6 +188,7 @@
 
 .ts-control {
   @extend .text_field;
+  min-height: calc(1.25rem + 1rem + 2px);
   width: 100%;
   overflow: hidden;
   position: relative;

--- a/app/javascript/stylesheets/tom_select.scss
+++ b/app/javascript/stylesheets/tom_select.scss
@@ -24,7 +24,7 @@
     color-adjust: exact;
   }
   &.focus .ts-control {
-    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' transform='rotate(180,-10,-10)' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' transform='rotate(180,0,0)' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
   }
 }
 


### PR DESCRIPTION
## Adds a min height to the dropdown, like TomSelect does in its own CSS: 

From:

![image](https://user-images.githubusercontent.com/14905290/146522344-69468b89-add0-4f9d-af55-5cb57482e72f.png)


To:

![image](https://user-images.githubusercontent.com/14905290/146522253-b8740e13-b955-4494-a1a3-63edc331dbc7.png)


## Rotates the dropdown caret correctly on focus

Before it was invisible on focus, but now it shows and rotates from:

![image](https://user-images.githubusercontent.com/14905290/146522492-ce5f0aec-5729-4216-9bd5-a908be806c0e.png)

to

![image](https://user-images.githubusercontent.com/14905290/146522455-fe0facf1-ccd3-4e7c-baaa-7e3faab4ce7a.png)
