### PR TITLE
Allow review.price to be input with a space by user

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -45,7 +45,7 @@ class Review < ApplicationRecord
 
   # Allows user to input a number with spaces, e.g. "30 000", without the system breaking
   def remove_spaces_from_price
-    price.gsub!(/\s+/, "")
+    price.gsub!(/\s+/, "") if price?.present?
   end
 
   ICONS_FOR_TYPE_OF_CONTACT = {

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -14,6 +14,8 @@ class Review < ApplicationRecord
   enum how_long: { custom_how_long: 0, one_weekend: 1, one_evening: 2 }
   enum type_of_contact: { only_contacted: 0, not_allowed_to_use: 1, been_there: 2 }
 
+  before_validation { remove_spaces_from_price }
+
   validates :title,
             length: { minimum: 4, maximum: 80 },
             presence: true,
@@ -39,6 +41,11 @@ class Review < ApplicationRecord
       review: self,
       facility: facility
     )
+  end
+
+  # Allows user to input a number with spaces, e.g. "30 000", without the system breaking
+  def remove_spaces_from_price
+    price.gsub!(/\s+/, "")
   end
 
   ICONS_FOR_TYPE_OF_CONTACT = {

--- a/db/migrate/20220118072558_change_reveiew_price_column_to_string.rb
+++ b/db/migrate/20220118072558_change_reveiew_price_column_to_string.rb
@@ -1,0 +1,5 @@
+class ChangeReveiewPriceColumnToString < ActiveRecord::Migration[6.1]
+  def change
+    change_column :reviews, :price, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_09_101806) do
+ActiveRecord::Schema.define(version: 2022_01_18_072558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 2021_12_09_101806) do
   create_table "reviews", force: :cascade do |t|
     t.string "title"
     t.string "comment"
-    t.integer "price"
+    t.string "price"
     t.decimal "star_rating", precision: 2, scale: 1
     t.bigint "user_id", null: false
     t.bigint "space_id", null: false

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 # Model test here, requests spec follows below
 RSpec.describe Review, type: :model do
-  it "can add a review" do
-    review = Fabricate(:review)
+  it "can add a review of type :been_there" do
+    review = Fabricate(:review, type_of_contact: :been_there)
     Fabricate(:facility_review, review: review)
     expect(review.title).to be_truthy
     expect(review.space).to be_truthy
@@ -14,6 +14,45 @@ RSpec.describe Review, type: :model do
     expect(review.star_rating).to be_truthy
     expect(review.user).to be_truthy
     expect(review.facility_reviews.count).to be 1
+  end
+
+  it "can add a review of type :not_allowed_to_use" do
+    review = Fabricate(:review,
+                       type_of_contact: :not_allowed_to_use,
+                       price: nil,
+                       star_rating: nil)
+    Fabricate(:facility_review, review: review)
+    expect(review.title).to be_truthy
+    expect(review.space).to be_truthy
+    expect(review.comment).to be_truthy
+    expect(review.user).to be_truthy
+    expect(review.facility_reviews.count).to be 1
+
+    expect(review.price).to be_nil
+    expect(review.star_rating).to be_nil
+  end
+
+  it "can add a review of type :only_contacted" do
+    review = Fabricate(
+      :review,
+      type_of_contact: :only_contacted,
+      price: nil,
+      star_rating: nil,
+      title: nil,
+      comment: nil,
+      facility_reviews: [
+        Fabricate(:facility_review)
+      ]
+    )
+
+    expect(review.space).to be_truthy
+    expect(review.user).to be_truthy
+    expect(review.facility_reviews.count).to be 1
+
+    expect(review.title).to be_nil
+    expect(review.comment).to be_nil
+    expect(review.price).to be_nil
+    expect(review.star_rating).to be_nil
   end
 
   it "sets stars and facility_reviews for a Space when adding and removing a review" do

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -71,4 +71,12 @@ RSpec.describe Review, type: :model do
 
     expect(review.facility_reviews.count).to eq(1)
   end
+
+  it "allows spaces in price user input" do
+    review = Fabricate(:review, price: 10)
+    review.price = "30 000"
+    review.save!
+    review.reload
+    expect(review.price).to eq("30000")
+  end
 end


### PR DESCRIPTION
This solves a user issue we found in user testing, where the user set the price of a review to "30 000" and was rebuked. It does so by doing two things: Storing the price as a string (we won't do calculations on it anyway), and replacing " " with "" on that string before validating that it's still a number.

We might want to remove the validation that it's a number entirely, so someone can write "Price: We had to volunteer in the gardens" but I'm not sure if that's useful or just allows for too much weird formatting on the numbers. 