### PR TITLE
Søkeboks sette focus når du åpner den og lukke boksen på enter

### DIFF
--- a/app/javascript/controllers/mapbox_controller.js
+++ b/app/javascript/controllers/mapbox_controller.js
@@ -18,6 +18,8 @@ export default class extends Controller {
 
   toggleSearchBox() {
     this.searchBoxTarget.classList.toggle("hidden");
+    let searchField = document.getElementById("locationInput-ts-control");
+    searchField.focus();
   }
 
   requestPosition() {
@@ -345,4 +347,3 @@ export default class extends Controller {
     }
   }
 }
-

--- a/app/javascript/controllers/mapbox_controller.js
+++ b/app/javascript/controllers/mapbox_controller.js
@@ -22,6 +22,12 @@ export default class extends Controller {
     searchField.focus();
   }
 
+  closeModal(e) {
+    if (e.key === "Enter") {
+      this.toggleSearchBox();
+    }
+  }
+
   requestPosition() {
     const options = {
       enableHighAccuracy: true,

--- a/app/views/spaces/index/_search_form.html.erb
+++ b/app/views/spaces/index/_search_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with data: { mapbox_target: 'form' } do |f| %>
+<%= form_with data: { mapbox_target: 'form', action: "keydown->mapbox#closeModal" } do |f| %>
   <div class="my-4">
     <%= f.label t("space_filter.location"), class: "text-xl font-bold" %>
     <div class="mt-2">


### PR DESCRIPTION
[Denne PR løser to ting: ](https://trello.com/c/pAhCEUx8/224-s%C3%B8keboks-sette-focus-n%C3%A5r-du-%C3%A5pner-den-og-lukke-boksen-p%C3%A5-enter)

1. Når du klikker søke filter knappen vil den autofokuse på tekstfeltet
2. Når du trykker enter uansett sted inne i modalen vil modalen lukkes

Issues oppdaget: Søket kjøres ikke når modalen lukkes (både på enter og med klikk), det betyr at man for eksempel blir vist Fredrikstad, men må klikke på kartet for å få opp søkeresultatene for det området. 