### PR TITLE
Search button revamp

### DIFF
--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -8,6 +8,15 @@ module ModalHelper
     end
   end
 
+  def modal_link_to_with_block(path, **options, &block)
+    id = options[:id] || path
+    turbo_frame_tag id do
+      link_to path, **options do
+        yield block
+      end
+    end
+  end
+
   def modal_content_for(id, parent, &block)
     render partial: "shared/modal", locals: {
       id: id,

--- a/app/javascript/controllers/mapbox_controller.js
+++ b/app/javascript/controllers/mapbox_controller.js
@@ -60,7 +60,11 @@ export default class extends Controller {
   }
 
   updateFilterCapsules() {
-    const capsuleHtml = (title) => `<button data-action="click->mapbox#disableCapsule" class="bg-white px-2 mt-2 rounded-full border border-gray-200 hover:border-lnu-pink whitespace-nowrap">${title}</button>`
+    const capsuleHtml = (title) => `<button
+        data-action="click->mapbox#disableCapsule"
+        class="bg-white px-2.5 py-0.5 mt-2 rounded-full border border-gray-200 hover:border-lnu-pink whitespace-nowrap">
+          ${title}
+        </button>`
 
     const facilityCapsules = this.facilityTargets.map(t =>
       t.checked ? capsuleHtml(t.id) : ''

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -28,7 +28,6 @@ class Space < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_rich_text :pricing
   has_rich_text :terms
   has_rich_text :more_info
-  has_rich_text :facility_description
 
   include ParseUrlHelper
   before_validation :parse_url

--- a/app/views/spaces/index/_filter_button.html.erb
+++ b/app/views/spaces/index/_filter_button.html.erb
@@ -1,4 +1,4 @@
-<nav class="fixed md:sticky m-4 md:m-0 z-10 top-0 md:top-14 right-0 left-0 flex justify-center md:block md:px-4 md:pt-4 md:mb-8">
+<nav class="fixed md:sticky m-4 md:m-0 z-10 top-0 md:top-14 right-0 left-0 justify-center md:block md:px-4 md:pt-4 md:mb-8">
   <button
     id="toggle_search_box"
     data-action="click->mapbox#toggleSearchBox"

--- a/app/views/spaces/index/_filter_button.html.erb
+++ b/app/views/spaces/index/_filter_button.html.erb
@@ -1,29 +1,22 @@
 <nav class="fixed md:sticky m-4 md:m-0 z-10 top-0 md:top-14 right-0 left-0 flex justify-center md:block md:px-4 md:pt-4 md:mb-8">
-  <div class="border-white w-full md:w-full border-2 py-3 px-4 bg-white rounded-md shadow-xl ">
+  <button
+    id="toggle_search_box"
+    data-action="click->mapbox#toggleSearchBox"
+    class="border-white hover:border-lnu-pink w-full md:w-full border-2 py-3 px-4 bg-white rounded-md shadow-xl ">
     <span class="flex justify-between">
-      <button
-          id="toggle_search_box"
-          data-action="click->mapbox#toggleSearchBox"
-          class="flex justify-between w-full pr-2">
-        <span class="inline-flex items-center justify-start border-2 rounded-full border-white hover:border-lnu-pink">
+        <span class="inline-flex items-center justify-start">
           <%= inline_svg_tag 'search', class: 'inline-block' %>
         </span>
 
-        <span class="inline-flex items-center w-full justify-center border-2 rounded-full border-white hover:border-lnu-pink" id="searchbox-text">
+        <span class="inline-flex items-center w-full justify-center" id="searchbox-text">
           <%= t('space_filter.search_and_filter') %>
         </span>
 
-        <span class="inline-flex items-center justify-end hover:border-lnu-pink border-2 rounded-full border-white hover:border-lnu-pink">
+        <span class="inline-flex items-center justify-end">
           <span id="searchbox-count"></span>
           <%= inline_svg_tag 'filter', class: 'inline-block' %>
         </span>
-      </button>
-
-      <button class="inline-flex items-center justify-end border-2 rounded-full border-white hover:border-lnu-pink gap-2" data-action="click->mapbox#enableLocationService">
-        <%= inline_svg_tag 'gps', class: 'inline-block' %>
-      </button>
     </span>
-    <span data-mapbox-target="filterCapsules" class="flex overflow-x-auto gap-1">
-    </span>
-  </div>
+  </button>
+  <span data-mapbox-target="filterCapsules" class="flex overflow-x-auto gap-1"></span>
 </nav>

--- a/app/views/spaces/index/_map.html.erb
+++ b/app/views/spaces/index/_map.html.erb
@@ -3,17 +3,19 @@
   <div class="w-full h-full md:h-full" id="map-frame"></div>
 
   <div class="justify-center w-full flex hidden" data-mapbox-target="searchArea">
-    <button data-action="click->mapbox#reloadPosition" class="absolute top-0 p-1 px-2 mr-4 mt-28 bg-white rounded-xl hover:border-lnu-pink border-white border-2 shadow-xl md:mt-2">
+    <button
+      data-action="click->mapbox#reloadPosition"
+      class="absolute top-0 p-1 px-2 mr-4 mt-36 md:mt-2 bg-white rounded-xl hover:border-lnu-pink border-white border-2 shadow-xl">
       <%= inline_svg_tag 'reload', class: 'inline-block' %>
       <%= t('space_filter.map_reload') %>
     </button>
   </div>
 
-  <div class="absolute bottom-20 right-6">
+  <div class="absolute bottom-12 right-4 md:right-6 md:bottom-20">
     <button
       data-action="click->mapbox#enableLocationService"
       class="
-    bg-white p-2 items-center justify-center border-2 rounded-full border-white hover:border-lnu-pink gap-2">
+    bg-white h-12 w-12 items-center justify-center border-2 rounded-full border-white hover:border-lnu-pink gap-2">
       <%= inline_svg_tag 'gps', class: 'inline-block' %>
     </button>
   </div>

--- a/app/views/spaces/index/_map.html.erb
+++ b/app/views/spaces/index/_map.html.erb
@@ -8,4 +8,13 @@
       <%= t('space_filter.map_reload') %>
     </button>
   </div>
+
+  <div class="absolute bottom-20 right-6">
+    <button
+      data-action="click->mapbox#enableLocationService"
+      class="
+    bg-white p-2 items-center justify-center border-2 rounded-full border-white hover:border-lnu-pink gap-2">
+      <%= inline_svg_tag 'gps', class: 'inline-block' %>
+    </button>
+  </div>
 </div>

--- a/app/views/spaces/show/_facilities.html.erb
+++ b/app/views/spaces/show/_facilities.html.erb
@@ -1,34 +1,38 @@
-<div id="facilities">
-  <%= inline_editable :facility_description  do %>
-    <%= @space.facility_description %>
-  <% end %>
+<section id="facilities">
 
-  <%= modal_link_to t('facility_reviews.edit'),
-                    new_facility_review_path(@space),
-                    id: :new_facility_review_path,
-                    class: 'unstyled-link edit-button collapsable' %>
+  <header class="editable-header-type-h2 flex gap-3 items-baseline">
+    <h2><%= Facility.model_name.human(count: 2) %></h2>
+    <%= modal_link_to_with_block new_facility_review_path(@space),
+                      id: :new_facility_review_path,
+                      class: 'unstyled-link edit-button collapsable' do %>
+        <span class="text">
+          Redigér
+        </span>
+      <%= inline_svg_tag 'edit', alt: 'Redigér', title: 'Redigér' %>
+    <% end %>
 
+  </header>
 
-  <h2><%= Facility.model_name.human(count: 2) %></h2>
+  <main class="grid divide-y">
+    <% FacilityCategory.all.each_with_index do |facilityCategory| %>
+      <div class="grid md:grid-cols-3 md:gap-4 items-baseline py-4 md:py-8">
+        <h3 class="no-mt">
+          <%= facilityCategory.title %>
+        </h3>
 
-  <% FacilityCategory.all.each_with_index do |facilityCategory, index| %>
-    <%=
-      # Header isn't needed if these are just the normal facilities, and
-      # we don't have any selected. When we do get 'filtered' or 'selected'
-      # facilities ("Facilities we are looking for"), also the first facilityCategory
-      # header should be included as "Andre fasiliteter"
-      tag.h3 facilityCategory.title unless index == 0
-    %>
+        <ul class="grid gap-1 md:col-span-2">
+          <% @space.facilities_in_category(facilityCategory).each do |facility| %>
+            <%= render partial: 'spaces/show/facility_item', locals: {
+              title: facility[:title],
+              review: facility[:review],
+              description: facility[:description],
+              tooltip: t("tooltips.facility_aggregated_experience.#{facility[:review]}")
+            } %>
+          <% end %>
+        </ul>
+      </div>
 
-    <ul class="grid grid-cols-1 gap-2 mt-2">
-      <% @space.facilities_in_category(facilityCategory).each do |facility| %>
-        <%= render partial: 'spaces/show/facility_item', locals: {
-          title: facility[:title],
-          review: facility[:review],
-          description: facility[:description],
-          tooltip: t("tooltips.facility_aggregated_experience.#{facility[:review]}")
-        } %>
-      <% end %>
-    </ul>
-  <% end %>
-</div>
+    <% end %>
+  </main>
+
+</section>

--- a/app/views/spaces/show/_facility_item.html.erb
+++ b/app/views/spaces/show/_facility_item.html.erb
@@ -1,13 +1,15 @@
 <li
-  class="flex items-center gap-1.5"
   title="<%= tooltip %>">
-  <%= title %>
-  <span>
-    <%= inline_svg_tag "facility_status/#{review}" %>
+  <span class="flex items-center gap-1.5">
+    <%= title %>
+      <span>
+      <%= inline_svg_tag "facility_status/#{review}" %>
+    </span>
   </span>
+  <% unless description.nil? %>
+    <p class="text-gray-400">
+      <%= description %>
+    </p>
+  <% end %>
+
 </li>
-<% unless description.nil? %>
-  <ul class="pl-8 list-disc text-gray-400">
-    <li><%= description %></li>
-  </ul>
-<% end %>


### PR DESCRIPTION
Takes a fresh look at the search buttons, and cleans up a litte.

![image](https://user-images.githubusercontent.com/14905290/152538781-9fb31022-397f-48c5-b7e3-300b5502eaa2.png)

Moves the  GPS button out to the map, in a new corner designated for "map manipulation buttons", such as a plus and minus (which I think we need to add after it was voiced in a user interview with someone who didn't have a great mouse at her disposal)
![image](https://user-images.githubusercontent.com/14905290/152538830-0fc2b7fc-8a6d-4f9d-96ce-465fc7a41292.png)

Moves the chosen facility buttons under the search bar: 

![image](https://user-images.githubusercontent.com/14905290/152538845-d4f3de62-5fd7-4b4a-88cb-e9fa5c412b93.png)

And cleans up the search bar so it's a complete button again:

![image](https://user-images.githubusercontent.com/14905290/152538879-949899c6-4dee-42e1-b851-cfa721c0a2ab.png)

