### PR TITLE
Clean up visually on Space#show facilities

### DIFF
--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -8,6 +8,15 @@ module ModalHelper
     end
   end
 
+  def modal_link_to_with_block(path, **options, &block)
+    id = options[:id] || path
+    turbo_frame_tag id do
+      link_to path, **options do
+        yield block
+      end
+    end
+  end
+
   def modal_content_for(id, parent, &block)
     render partial: "shared/modal", locals: {
       id: id,

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -28,7 +28,6 @@ class Space < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_rich_text :pricing
   has_rich_text :terms
   has_rich_text :more_info
-  has_rich_text :facility_description
 
   include ParseUrlHelper
   before_validation :parse_url

--- a/app/views/spaces/show/_facilities.html.erb
+++ b/app/views/spaces/show/_facilities.html.erb
@@ -11,20 +11,26 @@
 
   <h2><%= Facility.model_name.human(count: 2) %></h2>
 
-  <% FacilityCategory.all.each_with_index do |facilityCategory| %>
-    <%=
-      tag.h3 facilityCategory.title
-    %>
+  <div class="grid divide-y">
+    <% FacilityCategory.all.each_with_index do |facilityCategory| %>
+      <div class="grid md:grid-cols-3 md:gap-4 items-baseline py-4 md:py-8">
+        <h3 class="no-mt">
+          <%= facilityCategory.title %>
+        </h3>
 
-    <ul class="grid grid-cols-1 gap-2 mt-2">
-      <% @space.facilities_in_category(facilityCategory).each do |facility| %>
-        <%= render partial: 'spaces/show/facility_item', locals: {
-          title: facility[:title],
-          review: facility[:review],
-          description: facility[:description],
-          tooltip: t("tooltips.facility_aggregated_experience.#{facility[:review]}")
-        } %>
-      <% end %>
-    </ul>
-  <% end %>
+        <ul class="grid gap-1 md:col-span-2">
+          <% @space.facilities_in_category(facilityCategory).each do |facility| %>
+            <%= render partial: 'spaces/show/facility_item', locals: {
+              title: facility[:title],
+              review: facility[:review],
+              description: facility[:description],
+              tooltip: t("tooltips.facility_aggregated_experience.#{facility[:review]}")
+            } %>
+          <% end %>
+        </ul>
+      </div>
+
+    <% end %>
+  </div>
+
 </div>

--- a/app/views/spaces/show/_facilities.html.erb
+++ b/app/views/spaces/show/_facilities.html.erb
@@ -11,13 +11,9 @@
 
   <h2><%= Facility.model_name.human(count: 2) %></h2>
 
-  <% FacilityCategory.all.each_with_index do |facilityCategory, index| %>
+  <% FacilityCategory.all.each_with_index do |facilityCategory| %>
     <%=
-      # Header isn't needed if these are just the normal facilities, and
-      # we don't have any selected. When we do get 'filtered' or 'selected'
-      # facilities ("Facilities we are looking for"), also the first facilityCategory
-      # header should be included as "Andre fasiliteter"
-      tag.h3 facilityCategory.title unless index == 0
+      tag.h3 facilityCategory.title
     %>
 
     <ul class="grid grid-cols-1 gap-2 mt-2">

--- a/app/views/spaces/show/_facilities.html.erb
+++ b/app/views/spaces/show/_facilities.html.erb
@@ -1,17 +1,19 @@
-<div id="facilities">
-  <%= inline_editable :facility_description  do %>
-    <%= @space.facility_description %>
-  <% end %>
+<section id="facilities">
 
-  <%= modal_link_to t('facility_reviews.edit'),
-                    new_facility_review_path(@space),
-                    id: :new_facility_review_path,
-                    class: 'unstyled-link edit-button collapsable' %>
+  <header class="editable-header-type-h2 flex gap-3 items-baseline">
+    <h2><%= Facility.model_name.human(count: 2) %></h2>
+    <%= modal_link_to_with_block new_facility_review_path(@space),
+                      id: :new_facility_review_path,
+                      class: 'unstyled-link edit-button collapsable' do %>
+        <span class="text">
+          Redigér
+        </span>
+      <%= inline_svg_tag 'edit', alt: 'Redigér', title: 'Redigér' %>
+    <% end %>
 
+  </header>
 
-  <h2><%= Facility.model_name.human(count: 2) %></h2>
-
-  <div class="grid divide-y">
+  <main class="grid divide-y">
     <% FacilityCategory.all.each_with_index do |facilityCategory| %>
       <div class="grid md:grid-cols-3 md:gap-4 items-baseline py-4 md:py-8">
         <h3 class="no-mt">
@@ -31,6 +33,6 @@
       </div>
 
     <% end %>
-  </div>
+  </main>
 
-</div>
+</section>

--- a/app/views/spaces/show/_facility_item.html.erb
+++ b/app/views/spaces/show/_facility_item.html.erb
@@ -1,13 +1,15 @@
 <li
-  class="flex items-center gap-1.5"
   title="<%= tooltip %>">
-  <%= title %>
-  <span>
-    <%= inline_svg_tag "facility_status/#{review}" %>
+  <span class="flex items-center gap-1.5">
+    <%= title %>
+      <span>
+      <%= inline_svg_tag "facility_status/#{review}" %>
+    </span>
   </span>
+  <% unless description.nil? %>
+    <p class="text-gray-400">
+      <%= description %>
+    </p>
+  <% end %>
+
 </li>
-<% unless description.nil? %>
-  <ul class="pl-8 list-disc text-gray-400">
-    <li><%= description %></li>
-  </ul>
-<% end %>


### PR DESCRIPTION
This branch:

- [x] Cleans up the visuals around facilities on space#show
- [x] Removes the temporary rich text field we had for facility description, which is no longer welcome

It does not:
- [ ] Try to filter the facilities shown in any way, so we still show all 63... 

Desktop:

![image](https://user-images.githubusercontent.com/14905290/152546709-b78a2780-0997-4389-96ed-73f026637637.png)

Mobile:

![image](https://user-images.githubusercontent.com/14905290/152546740-5bb114ef-920f-4f46-94ad-1d6ef66de8f8.png)
