### PR TITLE
Privacy policy

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
       <%= render "shared/flash" %>
     </div>
     <%= render partial: "layouts/menu/menu" %>
-    <main>
+    <main class="flex-1">
       <%= yield %>
     </main>
     <footer class="px-2 pt-4 mt-4 pb-4 bg-gray-100">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <%= render 'application/favicon' %>
   </head>
 
-  <body class="pb-24 md:pb-0 md:pt-14">
+  <body class="pb-24 md:pb-0 md:pt-14 flex flex-col justify-between min-h-screen">
     <div id="flash">
       <%= render "shared/flash" %>
     </div>
@@ -20,5 +20,20 @@
     <main>
       <%= yield %>
     </main>
+    <footer class="px-2 pt-4 mt-4 pb-4 bg-gray-100">
+      <ul class="divide-x flex z-10 relative">
+        <li class="inline-block px-3">
+          <%= link_to t("menu.privacy_policy"),
+                      page_path("privacy_policy"),
+                      class: 'hover:underline text-sm text-gray-400 hover:text-gray-800' %>
+        </li>
+        <li class="inline-block px-3">
+          <%= link_to "lnu.no →",
+                      "https://lnu.no",
+                      class: 'hover:underline text-sm text-gray-400 hover:text-gray-800' %>
+        </li>
+
+      </ul>
+    </footer>
   </body>
 </html>

--- a/app/views/layouts/menu/_menu.html.erb
+++ b/app/views/layouts/menu/_menu.html.erb
@@ -1,9 +1,9 @@
-<% if current_user %>
-  <div class="fixed bottom-0 md:top-0 md:bottom-auto w-full z-10 h-24 md:h-14">
-    <nav class="flex justify-between  h-full bg-white p-4 leading-none top-shadow-lg md:shadow-lg z-10">
-      <div class="hidden md:block">
-        <%= render partial: 'layouts/menu/logo' %>
-      </div>
+<div class="fixed bottom-0 md:top-0 md:bottom-auto w-full z-10 h-24 md:h-14">
+  <nav class="flex justify-between h-full bg-white p-4 leading-none top-shadow-lg md:shadow-lg z-10">
+    <div class="hidden md:block">
+      <%= render partial: 'layouts/menu/logo' %>
+    </div>
+    <% if current_user %>
       <div class="flex justify-around gap-1 md:gap-6 w-full md:w-auto">
         <%= render partial: 'layouts/menu/menu_item', locals: {
           path: spaces_path,
@@ -27,6 +27,15 @@
         } %>
       </div>
       <div class="hidden lg:block lg:w-32"></div>
-    </nav>
-  </div>
-<% end %>
+  <% else %>
+      <div class="flex justify-around gap-1 md:gap-6 w-full md:w-auto">
+        <%= render partial: 'layouts/menu/menu_item', locals: {
+          path: spaces_path,
+          icon: 'account',
+          text: t('menu.log_in')
+        } %>
+      </div>
+    <% end %>
+  </nav>
+</div>
+

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -4,7 +4,7 @@
   <h1>Personvernserklæring for lokaler.lnu.no</h1>
   <h2>Generelt</h2>
   <p>Generelt lagrer vi så lite om deg som bruker siden som er praktisk mulig.</p>
-  <p>LNU - Landsrådet for Norges barne- og Ungdomsorganisasjoner er databehandler og ansvarlig for dataene.</p>
+  <p><a href="https://lnu.no">LNU - Landsrådet for Norges barne- og Ungdomsorganisasjoner</a> er behandlingsansvarlig og ansvarlig for dataene.</p>
   <p>Vi kan kontaktes på <a href="mailto:lokaler@lnu.no">lokaler@lnu.no</a></p>
   <h2>Vi lagrer følgende persondata om deg:</h2>
   <h3>Ditt navn og din e-post</h3>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,22 @@
+<% content_for(:html_title) { "Personvernserklæring" } %>
+
+<div class="content max-w-prose mx-auto p-4 pb-10 trix-content">
+  <h1>Personvernserklæring for lokaler.lnu.no</h1>
+  <h2>Generelt</h2>
+  <p>Generelt lagrer vi så lite om deg som bruker siden som er praktisk mulig.</p>
+  <p>LNU - Landsrådet for Norges barne- og Ungdomsorganisasjoner er databehandler og ansvarlig for dataene.</p>
+  <p>Vi kan kontaktes på <a href="mailto:lokaler@lnu.no">lokaler@lnu.no</a></p>
+  <h2>Vi lagrer følgende persondata om deg:</h2>
+  <h3>Ditt navn og din e-post</h3>
+  <p>Om du logger inn, og registrerer en bruker, så lagrer vi navnet du setter på brukeren og e-postadressen din.</p>
+  <p>Dette er for å kunne identifisere deg som bruker på siden. Dataene kan også brukes til å kontakte deg
+  om det skulle være noe rundt din bruk av siden.</p>
+  <p>Andre brukere på siden kan også se din e-post og navnet du har valgt.</p>
+  <h3>Din organisasjonstilknything</h3>
+  <p>Om du legger inn organisasjonstilknytningen din på brukerprofilen din eller i en anmeldelse av et lokale, så vil dette knyttes til din bruker og kunne leses av andre brukere på siden.</p>
+  <h3>All tekst du lagrer på siden</h3>
+  <p>Av åpenbare grunner lagrer vi all tekst du måtte skrive om et lokale eller på andre måter på siden, og som regel vil også andre besøkende ha tilgang til å se at du skrev teksten.</p>
+  <h2>Vi bruker følgende tredjepartstjenester som kan samle inn data om deg:</h2>
+  <p>Om du logger inn med Google vil Google vite at du bruker siden.</p>
+  <p>Dataene for siden lagres på Heroku, et amerikansk-eid selskap. Dataene lagres i Europa, men per Schrems II-dommen så kan amerikanske myndigheter fortsatt kreve dataene utlevert uten at vi vil få beskjed eller ha mulighet til å stoppe det.</p>
+</div>

--- a/config/locales/menu.nb.yml
+++ b/config/locales/menu.nb.yml
@@ -6,3 +6,4 @@ nb:
     account: 'Konto'
     other_sources: 'Andre kilder'
     log_in: 'Logg inn'
+    privacy_policy: 'Personvern'

--- a/config/locales/menu.nb.yml
+++ b/config/locales/menu.nb.yml
@@ -5,3 +5,4 @@ nb:
     about: 'Om siden'
     account: 'Konto'
     other_sources: 'Andre kilder'
+    log_in: 'Logg inn'


### PR DESCRIPTION
Adds a simple privacy policy page, as required by law and Google.

Also adds a simple footer to keep the privacy policy in:
<img width="420" alt="image" src="https://user-images.githubusercontent.com/14905290/153148639-fe21876f-c39d-466c-83bb-0413339b495a.png">

And shows the menu (sans menu items) when not logged in, to give context on the not-logged in privacy policy page.