### PR TITLE
Edit facilities

### DIFF
--- a/app/controllers/facility_reviews_controller.rb
+++ b/app/controllers/facility_reviews_controller.rb
@@ -12,8 +12,8 @@ class FacilityReviewsController < BaseControllers::AuthenticateController
     filter_not_matching_space_types
 
     @experiences = [
-      *FacilityReview.experiences.keys,
-      "unknown"
+      "unknown",
+      *FacilityReview.experiences.keys.reverse
     ].reverse
   end
 

--- a/app/controllers/facility_reviews_controller.rb
+++ b/app/controllers/facility_reviews_controller.rb
@@ -65,21 +65,25 @@ class FacilityReviewsController < BaseControllers::AuthenticateController
   private
 
   def filter_matching_space_types
+    @matching_space_types_count = 0
     @matching_space_types = @space.facilities_for_categories.filter_map do |category_id, facilities|
       result = facilities.filter do |facility|
         (facility[:space_types] & @space.space_types).any?
       end
 
+      @matching_space_types_count += result.count
       [category_id, result] if result.any?
     end.to_h
   end
 
   def filter_not_matching_space_types
+    @not_matching_space_types_count = 0
     @not_matching_space_types = @space.facilities_for_categories.filter_map do |category_id, facilities|
       result = facilities.filter do |facility|
         (facility[:space_types] & @space.space_types).empty?
       end
 
+      @not_matching_space_types_count += result.count
       [category_id, result] if result.any?
     end.to_h
   end

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -9,7 +9,7 @@ class SpacesController < BaseControllers::AuthenticateController # rubocop:disab
   def show
     @space = Space.includes(:space_contacts).where(id: params[:id]).first
     @space_contact = SpaceContact.new(space_id: @space.id, space_group_id: @space.space_group_id)
-    @facilities_for_categories = @space.facilities_for_categories(match_all_except_unknown: true)
+    @grouped_relevant_facilities = @space.relevant_facilities(grouped: true)
   end
 
   def new

--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -12,7 +12,9 @@ module ModalHelper
   end
 
   def button_close_modal(modal_id, **options, &block)
-    button_tag(**options, data: {
+    button_tag(
+      type: "button",
+      **options, data: {
                  controller: "modal",
                  "modal-target": "closeButton",
                  "modal-to-toggle": modal_id

--- a/app/helpers/modal_helper.rb
+++ b/app/helpers/modal_helper.rb
@@ -15,10 +15,11 @@ module ModalHelper
     button_tag(
       type: "button",
       **options, data: {
-                 controller: "modal",
-                 "modal-target": "closeButton",
-                 "modal-to-toggle": modal_id
-               }) do
+        controller: "modal",
+        "modal-target": "closeButton",
+        "modal-to-toggle": modal_id
+      }
+    ) do
       yield block
     end
   end

--- a/app/javascript/controllers/equal_checkboxes_handler_controller.js
+++ b/app/javascript/controllers/equal_checkboxes_handler_controller.js
@@ -8,14 +8,84 @@ export default class extends Controller {
   static targets = ['form']
 
   connect() {
-    const checkboxes = this.formTarget.querySelectorAll('input[type=checkbox]')
+    this.handleDuplicateCheckboxesAndRadios()
+    this.handleDuplicateTextInputs()
+  }
 
-    checkboxes.forEach(checkbox => {
-      checkbox.onclick = (e) => {
-        const clicked_box = e.target
-        const same_id = this.formTarget.querySelectorAll(`input[id=${clicked_box.id}]`)
-        same_id.forEach(checkbox => checkbox.checked = clicked_box.checked)
-      }
+  handleDuplicateTextInputs() {
+    // First we get all input fields (no support for textareas yet)
+    const input_fields = [
+      ...this.formTarget.querySelectorAll('input[type=text]')
+    ]
+
+    // Then we get duplicates, grouped by id:
+    const grouped_duplicates = this.group_duplicates(input_fields)
+
+    grouped_duplicates.forEach((group) => {
+      group.forEach((field, index) => {
+        // Equalize all checked values:
+        // TODO: HANDLE FOR INPUTS
+      })
     })
+
+  }
+
+  handleDuplicateCheckboxesAndRadios() {
+    // First we get all checkboxes and radio buttons (no support for input fields yet)
+    const input_fields = [
+      ...this.formTarget.querySelectorAll('input[type=checkbox]'),
+      ...this.formTarget.querySelectorAll('input[type=radio]'),
+    ]
+
+    // Then we get duplicates, grouped by id:
+    const grouped_duplicates = this.group_duplicates(input_fields)
+
+    // Then we handle everything:
+    grouped_duplicates.forEach((group) => {
+      group.forEach((field, index) => {
+        // Equalize all checked values:
+        field.checked = group[group.length - 1].checked
+
+        // Set a click handler:
+        field.onclick = () => {
+          group.forEach(duplicate => duplicate.checked = field.checked)
+        }
+
+        // Only do the rest for the duplicates:
+        if (index === 0) return
+
+        // Add unique ids:
+        field.dataset.original_id = field.id
+        field.id = `${field.id}-${index}`
+
+        // Update labels with correct for
+        const label = field.parentElement.querySelector(`label[for=${field.dataset.original_id}]`)
+        label.setAttribute('for', field.id)
+
+        // Set a fake namm:
+        field.setAttribute('name', `duplicate_${index}_of_${field.name}`)
+
+        // Then check again, as it's lost when name is set:
+        field.checked = group[0].checked
+      })
+    })
+  }
+
+  group_duplicates(input_fields) {
+    // Pretty sure this could be handled with a .reduce or something...
+    const id_count = {}
+    input_fields.forEach(input => {
+      id_count[input.id] = id_count[input.id] ? 1 + id_count[input.id] : 1
+    })
+
+    const duplicate_input_fields = input_fields.filter(input => id_count[input.id] > 1 )
+
+    const grouped_duplicates = duplicate_input_fields.reduce((group, field) => {
+      group[field.id] = group[field.id] ?  [...group[field.id], field] : [field]
+      return group
+    }, {})
+
+    return Object.values(grouped_duplicates)
+    // [ [field, field], [field, field] ... ]
   }
 }

--- a/app/javascript/controllers/hide_controller.js
+++ b/app/javascript/controllers/hide_controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
 
     if (hideable.classList.contains("hidden")) return;
 
-    if (this.focusableTarget) {
+    if (this.hasFocusableTarget) {
       this.focusableTarget.focus()
     }
   }

--- a/app/javascript/controllers/hide_controller.js
+++ b/app/javascript/controllers/hide_controller.js
@@ -17,7 +17,11 @@ export default class extends Controller {
     if (hideable.classList.contains("hidden")) return;
 
     if (this.hasFocusableTarget) {
-      this.focusableTarget.focus()
+      // For non radio groups, just focus the element:
+      if (this.focusableTarget.getAttribute('role') !== "radiogroup") return this.focusableTarget.focus()
+
+      // For radio groups, focus the current checked element:
+      this.focusableTarget.querySelector("input[checked]").focus()
     }
   }
 }

--- a/app/javascript/controllers/hide_controller.js
+++ b/app/javascript/controllers/hide_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="hide"
+export default class extends Controller {
+  static targets = ["hideable", "focusable"]
+
+  connect() {
+    if (!this.hideableTarget) {
+      return console.error("Missing hideable target for hide controller")
+    }
+  }
+
+  toggleHidden() {
+    const hideable = this.hideableTarget
+    hideable.classList.toggle("hidden")
+
+    if (hideable.classList.contains("hidden")) return;
+
+    if (this.focusableTarget) {
+      this.focusableTarget.focus()
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -16,6 +16,9 @@ application.register("equal-checkboxes-handler", EqualCheckboxesHandlerControlle
 import FlashController from "./flash_controller.js"
 application.register("flash", FlashController)
 
+import HideController from "./hide_controller.js"
+application.register("hide", HideController)
+
 import LocationsearchController from "./locationsearch_controller.js"
 application.register("locationsearch", LocationsearchController)
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,8 +10,8 @@ application.register("autofilladdress", AutofilladdressController)
 import DuplicateCheckerController from "./duplicate_checker_controller.js"
 application.register("duplicate-checker", DuplicateCheckerController)
 
-import EqualCheckboxesHandlerController from "./equal_checkboxes_handler_controller.js"
-application.register("equal-checkboxes-handler", EqualCheckboxesHandlerController)
+import SyncFieldsWithSameId from "./sync_fields_with_same_id.js"
+application.register("sync-fields-with-same-id", SyncFieldsWithSameId)
 
 import FlashController from "./flash_controller.js"
 application.register("flash", FlashController)

--- a/app/javascript/controllers/sync_fields_with_same_id.js
+++ b/app/javascript/controllers/sync_fields_with_same_id.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="equal-checkboxes-handler"
+// Connects to data-controller="sync-fields-with-same-id"
 export default class extends Controller {
   // Handles the case where a form has multiple check boxes with the same id,
   // by making sure they are all checked

--- a/app/javascript/stylesheets/common_elements.scss
+++ b/app/javascript/stylesheets/common_elements.scss
@@ -4,9 +4,25 @@ a,
   @apply rounded;
   &:hover {
     @apply underline;
+    &.collapsable {
+      .text {
+        max-width: 200px;
+        margin-right: 0.5em;
+      }
+    }
   }
   &:focus {
     @extend .focused-outline;
+  }
+  &.collapsable {
+    @apply inline-flex gap-0;
+    .text {
+      max-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      @apply transition-all;
+    }
   }
 }
 

--- a/app/javascript/stylesheets/editable.scss
+++ b/app/javascript/stylesheets/editable.scss
@@ -6,6 +6,10 @@
 }
 .edit-button {
   @apply rounded-lg py-2 px-3;
+  &.edit-button--small {
+    @apply rounded-lg py-1 px-1.5;
+    @apply text-sm;
+  }
   @apply bg-gray-100 border border-gray-100;
   @apply inline-flex gap-2 content-center items-center;
   @apply text-gray-700;

--- a/app/javascript/stylesheets/forms.scss
+++ b/app/javascript/stylesheets/forms.scss
@@ -18,7 +18,7 @@
     display: none;
   }
   &.submit,
-  &.not[class=no-submit-styling][type=submit] {
+  &[type=submit]:not(.no-submit-styling) {
     @apply bg-pink-700 text-white;
     &:hover {
       @apply bg-pink-600 border-pink-600;

--- a/app/javascript/stylesheets/radio_slider.scss
+++ b/app/javascript/stylesheets/radio_slider.scss
@@ -4,7 +4,7 @@
   @apply p-0.5 rounded-xl;
   @apply inline-flex gap-1 items-stretch flex-wrap;
   &:focus-within {
-    @apply border-gray-300 bg-gray-50;
+    @apply outline-none ring-2 ring-offset-2 ring-lnu-pink;
   }
   input[type="radio"] {
     @apply sr-only;

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -50,72 +50,6 @@ class Space < ApplicationRecord # rubocop:disable Metrics/ClassLength
     space_facilities.find_by(facility: facility).experience
   end
 
-  # Facilities that are typically relevant for the space
-  # Either because they share a space type with the space
-  # or because someone has said that they are relevant for
-  # this specific space by setting a space_facilities experience.
-  #
-  # Can be grouped by category by passing grouped: true
-  def relevant_facilities(grouped: false)
-    all_space_f = space_facilities
-                  .includes(facility: [:facilities_categories, :space_types])
-
-    result = all_space_f
-             .where(facility: { space_types: space_types })
-             .or(
-               all_space_f
-                 .where.not(experience: [:impossible, :unknown])
-             ).distinct
-
-    return result unless grouped
-
-    group_space_facilities(result)
-  end
-
-  # Facilities that are typically NOT relevant for the space
-  # Because they DO NOT share a space type with the space AND
-  # no one has given a space_facility experience for them.
-  #
-  # Can be grouped by category by passing grouped: true
-  def non_relevant_facilities(grouped: false)
-    all_space_f = space_facilities
-                  .includes(facility: [:facilities_categories, :space_types])
-
-    result = all_space_f
-             .where.not(facility: { space_types: space_types })
-             .or(
-               all_space_f.where(facility: { space_types: nil })
-             )
-             .and(
-               all_space_f
-                 .where(experience: [:impossible, :unknown])
-             ).distinct
-
-    return result unless grouped
-
-    group_space_facilities(result)
-  end
-
-  # Groups given facilities by their category
-  # { category_id: [facility_1, facility_2, ...] }
-  def group_space_facilities(ungrouped_facilities) # rubocop:disable Metrics/AbcSize
-    ungrouped_facilities.each_with_object({}) do |space_facility, memo|
-      space_facility.facility.facilities_categories.each do |facility_category|
-        memo[facility_category.facility_category_id] ||= {
-          category: facility_category.facility_category,
-          space_facilities: []
-        }
-        memo[facility_category.facility_category_id][:space_facilities] << {
-          id: space_facility.facility.id,
-          title: space_facility.facility.title,
-          description: space_facility.description,
-          review: space_facility.experience,
-          space_types: space_facility.facility.space_types
-        }
-      end
-    end.sort_by(&:first) # sorts by category id
-  end
-
   def self.rect_of_spaces
     south_west_lat = 90
     south_west_lng = 180
@@ -193,7 +127,7 @@ class Space < ApplicationRecord # rubocop:disable Metrics/ClassLength
     results.sort_by(&:score).map(&:space)
   end
 
-  # Groupes all of the users facility reviews into a hash like
+  # Groups all of the users facility reviews into a hash like
   # { category_id: { facility_id: review } }
   def reviews_for_categories(user)
     user.facility_reviews
@@ -206,6 +140,72 @@ class Space < ApplicationRecord # rubocop:disable Metrics/ClassLength
         memo[facility_category.facility_category_id][review.facility.id] = review
       end
     end
+  end
+
+  # Facilities that are typically relevant for the space
+  # Either because they share a space type with the space
+  # or because someone has said that they are relevant for
+  # this specific space by setting a space_facilities experience.
+  #
+  # Can be grouped by category by passing grouped: true
+  def relevant_facilities(grouped: false)
+    all_space_f = space_facilities
+                  .includes(facility: [:facilities_categories, :space_types])
+
+    result = all_space_f
+             .where(facility: { space_types: space_types })
+             .or(
+               all_space_f
+                 .where.not(experience: [:impossible, :unknown])
+             ).distinct
+
+    return result unless grouped
+
+    group_space_facilities(result)
+  end
+
+  # Facilities that are typically NOT relevant for the space
+  # Because they DO NOT share a space type with the space AND
+  # no one has given a space_facility experience for them.
+  #
+  # Can be grouped by category by passing grouped: true
+  def non_relevant_facilities(grouped: false)
+    all_space_f = space_facilities
+                  .includes(facility: [:facilities_categories, :space_types])
+
+    result = all_space_f
+             .where.not(facility: { space_types: space_types })
+             .or(
+               all_space_f.where(facility: { space_types: nil })
+             )
+             .and(
+               all_space_f
+                 .where(experience: [:impossible, :unknown])
+             ).distinct
+
+    return result unless grouped
+
+    group_space_facilities(result)
+  end
+
+  # Groups given facilities by their category
+  # { category_id: [facility_1, facility_2, ...] }
+  def group_space_facilities(ungrouped_facilities) # rubocop:disable Metrics/AbcSize
+    ungrouped_facilities.each_with_object({}) do |space_facility, memo|
+      space_facility.facility.facilities_categories.each do |facility_category|
+        memo[facility_category.facility_category_id] ||= {
+          category: facility_category.facility_category,
+          space_facilities: []
+        }
+        memo[facility_category.facility_category_id][:space_facilities] << {
+          id: space_facility.facility.id,
+          title: space_facility.facility.title,
+          description: space_facility.description,
+          review: space_facility.experience,
+          space_types: space_facility.facility.space_types
+        }
+      end
+    end.sort_by(&:first) # sorts by category id
   end
 
   def merge_paper_trail_versions

--- a/app/services/spaces/aggregate_facility_reviews_service.rb
+++ b/app/services/spaces/aggregate_facility_reviews_service.rb
@@ -34,7 +34,7 @@ module Spaces
       return space_facility.unknown! if count.zero?
 
       # Set criteria:
-      impossible_threshold = [(count / 2.0).ceil, 1].max
+      impossible_threshold = (count / 2.0).ceil
       positive_threshold = (count / 3.0 * 2.0).ceil
       negative_threshold = (count / 3.0 * 2.0).ceil
 

--- a/app/services/spaces/aggregate_facility_reviews_service.rb
+++ b/app/services/spaces/aggregate_facility_reviews_service.rb
@@ -34,7 +34,7 @@ module Spaces
       return space_facility.unknown! if count.zero?
 
       # Set criteria:
-      impossible_threshold = [(count / 2.0).ceil, 2].max
+      impossible_threshold = [(count / 2.0).ceil, 1].max
       positive_threshold = (count / 3.0 * 2.0).ceil
       negative_threshold = (count / 3.0 * 2.0).ceil
 

--- a/app/views/admin/space_types/_form.html.erb
+++ b/app/views/admin/space_types/_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for @space_type,
                     url: action_name == "new" ? admin_space_types_path : admin_space_type_path,
-                    data: { controller: "equal-checkboxes-handler", "equal-checkboxes-handler-target": "form" } do |f| %>
+                    data: { controller: "sync-fields-with-same-id", "sync-fields-with-same-id-target": "form" } do |f| %>
   <%= f.input :type_name %>
   <h2>Tilknyttede fasiliteter</h2>
   <% FacilityCategory.all.each do |category| %>

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -1,5 +1,10 @@
 <%= turbo_frame_tag :new_facility_review_path do %>
-  <%= simple_form_for "facility_reviews", url: create_facility_review_path(@space) do |form| %>
+  <%= simple_form_for "facility_reviews",
+                      url: create_facility_review_path(@space),
+                      data: {
+                        controller: 'equal-checkboxes-handler',
+                        'equal-checkboxes-handler-target': 'form'
+                      } do |form| %>
     <div class="modal-header">
       <h3><%= t("facility_reviews.edit") %></h3>
     </div>

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -22,9 +22,13 @@
         <% end %>
       <% end %>
       <% if @not_matching_space_types.present?  %>
-          <details>
-          <summary>
-            Others
+        <p class="text-gray-500">
+          Viser kun fasiliteter som er spesielle for <%= @space.title %> eller vanlige for
+          lokaler av typen "<%= @space.space_types.map{ |type| type.type_name }.to_sentence %>".
+        </p>
+        <details class="mb-8 group">
+          <summary class="button">
+            <span>Vis <%= @not_matching_space_types_count %> andre fasiliteter</span>
           </summary>
           <% @categories.each do |category| %>
             <%= render partial: 'facility_reviews/new/facility_category',

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -43,9 +43,9 @@
     </div>
     <div class="modal-footer">
       <%= form.submit class: "button submit" %>
-      <%= button_close_modal :new_facility_review_path do %>
+      <button type="button" data-action="click->modal#close" class="link">
         <%= t("space_contacts.abort") %>
-      <% end %>
+      </button>
     </div>
   <% end %>
 <% end %>

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -33,7 +33,7 @@
       <% end %>
     </div>
     <div class="modal-footer">
-      <%= form.submit %>
+      <%= form.submit class: "button submit" %>
       <%= button_close_modal :new_facility_review_path do %>
         <%= t("space_contacts.abort") %>
       <% end %>

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag :new_facility_review_path do %>
-  <%= form_for "facility_reviews", url: create_facility_review_path(@space) do |form| %>
+  <%= simple_form_for "facility_reviews", url: create_facility_review_path(@space) do |form| %>
     <div class="modal-header">
       <h3><%= t("facility_reviews.edit") %></h3>
     </div>

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -9,35 +9,34 @@
       <h3><%= t("facility_reviews.edit") %></h3>
     </div>
     <div class="modal-content content">
-      <% if @matching_space_types.present?  %>
-        <% @categories.each do |category| %>
+      <% if @grouped_relevant_facilities.present?  %>
+        <% @grouped_relevant_facilities.each do |group| %>
           <%= render partial: 'facility_reviews/new/facility_category',
             locals: {
-              facilities_in_category: @matching_space_types[category.id],
+              facilities_in_category: group.second[:space_facilities],
               form: form,
               review: form.object,
-              category: category,
-              only_matching: true
+              category: group.second[:category]
             } %>
         <% end %>
       <% end %>
-      <% if @not_matching_space_types.present?  %>
+      <% if @grouped_non_relevant_facilities.present?  %>
         <p class="text-gray-500">
           Viser kun fasiliteter som er spesielle for <%= @space.title %> eller vanlige for
           lokaler av typen "<%= @space.space_types.map{ |type| type.type_name }.to_sentence %>".
         </p>
         <details class="mb-8 group">
           <summary class="button">
-            <span>Vis <%= @not_matching_space_types_count %> andre fasiliteter</span>
+            <span>Vis <%= @non_relevant_facilities.count %> andre fasiliteter</span>
           </summary>
-          <% @categories.each do |category| %>
+          <% @grouped_non_relevant_facilities.each do |group| %>
             <%= render partial: 'facility_reviews/new/facility_category',
               locals: {
-                facilities_in_category: @not_matching_space_types[category.id],
+                facilities_in_category: group.second[:space_facilities],
                 form: form,
                 review: form.object,
-                category: category,
-                only_matching: false } %>
+                category: group.second[:category]
+              } %>
           <% end %>
         </details>
       <% end %>

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -3,7 +3,7 @@
     <div class="modal-header">
       <h3><%= t("facility_reviews.edit") %></h3>
     </div>
-    <div class="modal-content">
+    <div class="modal-content content">
       <% if @matching_space_types.present?  %>
         <% @categories.each do |category| %>
           <%= render partial: 'facility_reviews/new/facility_category',
@@ -12,7 +12,8 @@
               form: form,
               review: form.object,
               category: category,
-              only_matching: true } %>
+              only_matching: true
+            } %>
         <% end %>
       <% end %>
       <% if @not_matching_space_types.present?  %>

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -22,8 +22,9 @@
       <% end %>
       <% if @grouped_non_relevant_facilities.present?  %>
         <p class="text-gray-500">
-          Viser kun fasiliteter som er spesielle for <%= @space.title %> eller vanlige for
-          lokaler av typen "<%= @space.space_types.map{ |type| type.type_name }.to_sentence %>".
+          <%= t('facility_reviews.new.showing_relevant_facilities',
+                space_title:  @space.title,
+                space_types: @space.space_types.map{ |type| type.type_name }.to_sentence) %>
         </p>
         <details class="mb-8 group">
           <summary class="button">

--- a/app/views/facility_reviews/new.html.erb
+++ b/app/views/facility_reviews/new.html.erb
@@ -2,8 +2,8 @@
   <%= simple_form_for "facility_reviews",
                       url: create_facility_review_path(@space),
                       data: {
-                        controller: 'equal-checkboxes-handler',
-                        'equal-checkboxes-handler-target': 'form'
+                        controller: 'sync-fields-with-same-id',
+                        'sync-fields-with-same-id-target': 'form'
                       } do |form| %>
     <div class="modal-header">
       <h3><%= t("facility_reviews.edit") %></h3>

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -7,7 +7,7 @@ Locals:
 
 <li
   class="flex items-center gap-1.5">
-  <%= form.fields_for "reviews[#{facility[:id]}]", facility_review do |f| %>
+  <%= form.simple_fields_for "reviews[#{facility[:id]}]", facility_review do |f| %>
     <%= f.hidden_field :facility_id, value: facility[:id] %>
     <%= f.hidden_field :space_id, value: @space.id %>
     <%= f.hidden_field :user_id, value: current_user.id %>
@@ -29,8 +29,10 @@ Locals:
           <%= form.input :description,
                        label: false,
                        placeholder: t('simple_form.placeholders.space_facility.description'),
-                       name: "space_facilities[#{facility[:id]}][description]",
-                       value: facility[:description] %>
+                         input_html: {
+                           name: "space_facilities[#{facility[:id]}][description]",
+                           value: facility[:description]
+                         } %>
 
 
           <fieldset>

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -26,7 +26,7 @@ Locals:
         </legend>
 
         <div class="w-fit">
-          <%= form.input :description,
+          <%= form.input "space_facilities_#{facility[:id]}_description",
                        label: false,
                        placeholder: t('simple_form.placeholders.space_facility.description'),
                          input_html: {

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -13,37 +13,52 @@ Locals:
     <%= f.hidden_field :user_id, value: current_user.id %>
     <%= f.hidden_field :id, value: facility_review.id %>
 
-    <fieldset class="flex mt-3">
+    <fieldset class="mt-3 w-full">
         <legend class="mb-1">
-          <div class="flex gap-2 text-lg items-center mb-1 mt-3">
-            <%= facility[:title] %>
-            <%= inline_svg_tag "facility_status/#{facility[:review]}" %>
+          <div class="flex gap-2 text-lg items-center">
+            <h4 class="font-bold"><%= facility[:title] %></h4>
+
+            <span class="text-sm text-gray-400 items-center  flex gap-1">
+              <%= inline_svg_tag "facility_status/#{facility[:review]}" %>
+              <%= t("tooltips.facility_aggregated_experience.#{facility[:review]}") %>
+            </span>
           </div>
-          <div>
-            <%= f.label "Description" %>
-          </div>
-          <%= form.text_field :description, name: "space_facilities[#{facility[:id]}][description]", value: facility[:description] %>
         </legend>
 
-        <div class="radio-slider">
-          <% @experiences.each do |value|  %>
-            <%=
-              f.radio_button :experience,
-                value,
-                checked: f.object.experience.nil? ?
-                  value == 'unknown' :
-                  value == f.object.experience
-            %>
+        <div class="w-fit">
+          <%= form.input :description,
+                       label: false,
+                       placeholder: t('simple_form.placeholders.space_facility.description'),
+                       name: "space_facilities[#{facility[:id]}][description]",
+                       value: facility[:description] %>
 
-            <%= f.label :"experience_#{value}" do %>
-              <span class="flex flex-col items-center gap-0.5 text-sm">
-                <%= inline_svg_tag "facility_status/#{FacilityReview::ICON_FOR_EXPERIENCE[value]}",
-                   class: 'w-5 h-5 inline-block'
+
+          <fieldset>
+            <legend class="text-xs mb-1">
+              <%= t('simple_form.labels.space_facility.experience') %>
+            </legend>
+            <div class="radio-slider">
+              <% @experiences.each do |value|  %>
+                <%=
+                  f.radio_button :experience,
+                    value,
+                    checked: f.object.experience.nil? ?
+                      value == 'unknown' :
+                      value == f.object.experience
                 %>
-                <%= t("reviews.form.facility_experience_particular_tense.#{value}") %>
-              </span>
-            <% end %>
-          <% end %>
+
+                <%= f.label :"experience_#{value}" do %>
+                  <span class="flex flex-col items-center gap-0.5 text-sm">
+                    <%= inline_svg_tag "facility_status/#{FacilityReview::ICON_FOR_EXPERIENCE[value]}",
+                       class: 'w-5 h-5 inline-block'
+                    %>
+                    <%= t("reviews.form.facility_experience_particular_tense.#{value}") %>
+                  </span>
+                <% end %>
+              <% end %>
+            </div>
+          </fieldset>
+
         </div>
       </fieldset>
   <% end %>

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -18,7 +18,7 @@ Locals:
           <div class="flex gap-2 text-lg items-center">
             <h4 class="font-bold"><%= facility[:title] %></h4>
 
-            <span class="text-sm text-gray-400 items-center  flex gap-1">
+            <span class="text-sm text-gray-400 items-center flex gap-1" title="<%= t('simple_form.labels.space_facility.review') %>">
               <%= inline_svg_tag "facility_status/#{facility[:review]}" %>
               <%= t("tooltips.facility_aggregated_experience.#{facility[:review]}") %>
             </span>

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -49,7 +49,7 @@ Locals:
           </label>
           <%= form.input "space_facilities_#{facility[:id]}_description",
                        label: false,
-                       placeholder: t('simple_form.placeholders.space_facility.description'),
+                       placeholder: false,
                        label_html: {
                          class: "text-xs mb-1"
                        },

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -6,6 +6,7 @@ Locals:
 %>
 
 <li
+  data-controller="hide"
   class="flex items-center gap-1.5">
   <%= form.simple_fields_for "reviews[#{facility[:id]}]", facility_review do |f| %>
     <%= f.hidden_field :facility_id, value: facility[:id] %>
@@ -13,7 +14,7 @@ Locals:
     <%= f.hidden_field :user_id, value: current_user.id %>
     <%= f.hidden_field :id, value: facility_review.id %>
 
-    <fieldset class="mt-1 w-full" data-controller="hide">
+    <fieldset class="mt-1 w-full">
         <legend>
           <div class="flex gap-2 text-lg items-center">
             <h4 class="text-base"><%= facility[:title] %></h4>
@@ -23,7 +24,7 @@ Locals:
               <%= t("tooltips.others_experience.#{facility[:review]}") %>
             </span>
 
-            <button type="button" data-action="click->hide#toggleHidden" class="edit-button edit-button--small collapsable">
+            <button type="button" data-action="hide#toggleHidden" class="edit-button edit-button--small collapsable">
               <span class="text">
                 Redigér
               </span>
@@ -65,8 +66,8 @@ Locals:
             <legend class="text-xs mb-1">
               <%= t('simple_form.labels.space_facility.experience') %>
             </legend>
-            <div class="radio-slider"  role="radiogroup">
-              <% @experiences.each_with_index do |value, index|  %>
+            <div class="radio-slider" role="radiogroup" data-hide-target="focusable">
+              <% @experiences.each_with_index do |value|  %>
                 <%=
                   f.radio_button :experience,
                     value,

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -13,40 +13,60 @@ Locals:
     <%= f.hidden_field :user_id, value: current_user.id %>
     <%= f.hidden_field :id, value: facility_review.id %>
 
-    <fieldset class="mt-3 w-full">
+    <fieldset class="mt-3 w-full" data-controller="hide">
         <legend class="mb-1">
           <div class="flex gap-2 text-lg items-center">
-            <h4 class="font-bold"><%= facility[:title] %></h4>
+            <h4 class="text-base"><%= facility[:title] %></h4>
 
             <span class="text-sm text-gray-400 items-center flex gap-1" title="<%= t('simple_form.labels.space_facility.review') %>">
               <%= inline_svg_tag "facility_status/#{facility[:review]}" %>
-              <%= t("tooltips.facility_aggregated_experience.#{facility[:review]}") %>
+              <%= t("tooltips.others_experience.#{facility[:review]}") %>
             </span>
+
+            <button type="button" data-action="click->hide#toggleHidden" class="link inline-flex items-baseline gap-1">
+              <span class="text">
+                Redigér
+              </span>
+              <%= inline_svg_tag 'edit', alt: 'Redigér', title: 'Redigér' %>
+            </button>
+
           </div>
         </legend>
 
         <div class="w-fit">
+          <div class="flex gap-2">
+            <div class="text-gray-400 mb-1.5">
+              <%=  facility[:description] %>
+            </div>
+          </div>
+          <div data-hide-target="hideable" class="hidden">
           <%= form.input "space_facilities_#{facility[:id]}_description",
-                       label: false,
+                       label: t('simple_form.labels.space_facility.description'),
                        placeholder: t('simple_form.placeholders.space_facility.description'),
-                         input_html: {
-                           name: "space_facilities[#{facility[:id]}][description]",
-                           value: facility[:description]
-                         } %>
+                       label_html: {
+                         class: "text-xs mb-1"
+                       },
+                       required: false,
+                       input_html: {
+                         name: "space_facilities[#{facility[:id]}][description]",
+                         value: facility[:description]
+
+                       } %>
 
 
           <fieldset>
             <legend class="text-xs mb-1">
               <%= t('simple_form.labels.space_facility.experience') %>
             </legend>
-            <div class="radio-slider">
-              <% @experiences.each do |value|  %>
+            <div class="radio-slider"  role="radiogroup" data-hide-target="focusable">
+              <% @experiences.each_with_index do |value, index|  %>
                 <%=
                   f.radio_button :experience,
                     value,
                     checked: f.object.experience.nil? ?
                       value == 'unknown' :
                       value == f.object.experience
+
                 %>
 
                 <%= f.label :"experience_#{value}" do %>
@@ -60,7 +80,7 @@ Locals:
               <% end %>
             </div>
           </fieldset>
-
+          </div>
         </div>
       </fieldset>
   <% end %>

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -26,7 +26,7 @@ Locals:
 
             <button type="button" data-action="hide#toggleHidden" class="edit-button edit-button--small collapsable">
               <span class="text">
-                Redigér
+                <%= t('space_edit.edit') %>
               </span>
               <%= inline_svg_tag 'edit', alt: 'Redigér', title: 'Redigér' %>
             </button>

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -13,8 +13,8 @@ Locals:
     <%= f.hidden_field :user_id, value: current_user.id %>
     <%= f.hidden_field :id, value: facility_review.id %>
 
-    <fieldset class="mt-3 w-full" data-controller="hide">
-        <legend class="mb-1">
+    <fieldset class="mt-1 w-full" data-controller="hide">
+        <legend>
           <div class="flex gap-2 text-lg items-center">
             <h4 class="text-base"><%= facility[:title] %></h4>
 
@@ -23,7 +23,7 @@ Locals:
               <%= t("tooltips.others_experience.#{facility[:review]}") %>
             </span>
 
-            <button type="button" data-action="click->hide#toggleHidden" class="link inline-flex items-baseline gap-1">
+            <button type="button" data-action="click->hide#toggleHidden" class="edit-button edit-button--small collapsable">
               <span class="text">
                 Redigér
               </span>
@@ -33,15 +33,22 @@ Locals:
           </div>
         </legend>
 
-        <div class="w-fit">
-          <div class="flex gap-2">
-            <div class="text-gray-400 mb-1.5">
-              <%=  facility[:description] %>
-            </div>
+        <% if facility[:description] %>
+          <div class="text-gray-400 mb-1.5">
+            <%= facility[:description] %>
           </div>
-          <div data-hide-target="hideable" class="hidden">
+        <% end %>
+
+        <div class="w-fit hidden mt-1 mb-6" data-hide-target="hideable">
+
+          <label
+            for="<%= "space_facilities_#{facility[:id]}_description" %>"
+            class="text-xs mb-1 block"
+          >
+            <%=  t('simple_form.labels.space_facility.description') %>:
+          </label>
           <%= form.input "space_facilities_#{facility[:id]}_description",
-                       label: t('simple_form.labels.space_facility.description'),
+                       label: false,
                        placeholder: t('simple_form.placeholders.space_facility.description'),
                        label_html: {
                          class: "text-xs mb-1"
@@ -58,7 +65,7 @@ Locals:
             <legend class="text-xs mb-1">
               <%= t('simple_form.labels.space_facility.experience') %>
             </legend>
-            <div class="radio-slider"  role="radiogroup" data-hide-target="focusable">
+            <div class="radio-slider"  role="radiogroup">
               <% @experiences.each_with_index do |value, index|  %>
                 <%=
                   f.radio_button :experience,
@@ -80,7 +87,6 @@ Locals:
               <% end %>
             </div>
           </fieldset>
-          </div>
         </div>
       </fieldset>
   <% end %>

--- a/app/views/facility_reviews/new/_facility_buttons.html.erb
+++ b/app/views/facility_reviews/new/_facility_buttons.html.erb
@@ -17,10 +17,10 @@ Locals:
     <fieldset class="mt-1 w-full">
         <legend>
           <div class="flex gap-2 text-lg items-center">
-            <h4 class="text-base"><%= facility[:title] %></h4>
+            <h4 class="text-base <%= "line-through text-gray-600" if facility[:review] == "impossible" %>"><%= facility[:title] %></h4>
 
             <span class="text-sm text-gray-400 items-center flex gap-1" title="<%= t('simple_form.labels.space_facility.review') %>">
-              <%= inline_svg_tag "facility_status/#{facility[:review]}" %>
+              <%= inline_svg_tag "facility_status/#{facility[:review]}", class: "#{" text-black " if facility[:review] == "impossible" }" %>
               <%= t("tooltips.others_experience.#{facility[:review]}") %>
             </span>
 
@@ -80,7 +80,7 @@ Locals:
                 <%= f.label :"experience_#{value}" do %>
                   <span class="flex flex-col items-center gap-0.5 text-sm">
                     <%= inline_svg_tag "facility_status/#{FacilityReview::ICON_FOR_EXPERIENCE[value]}",
-                       class: 'w-5 h-5 inline-block'
+                       class: "w-5 h-5 inline-block"
                     %>
                     <%= t("reviews.form.facility_experience_particular_tense.#{value}") %>
                   </span>

--- a/app/views/facility_reviews/new/_facility_category.html.erb
+++ b/app/views/facility_reviews/new/_facility_category.html.erb
@@ -1,6 +1,6 @@
  <% if facilities_in_category.present? %>
   <%= tag.h3 category.title %>
-  <ul>
+  <ul class="flex flex-col gap-8">
     <% facilities_in_category.each do |facility_review| %>
       <%= render partial: 'facility_reviews/new/facility_buttons',
                  locals: {
@@ -10,4 +10,5 @@
                    form: form } %>
     <% end %>
   </ul>
+   <hr class="my-8" />
 <% end %>

--- a/app/views/facility_reviews/new/_facility_category.html.erb
+++ b/app/views/facility_reviews/new/_facility_category.html.erb
@@ -1,5 +1,5 @@
  <% if facilities_in_category.present? %>
-  <%= tag.h3 category.title unless category.id == "1" %>
+  <%= tag.h3 category.title %>
   <ul>
     <% facilities_in_category.each do |facility_review| %>
       <%= render partial: 'facility_reviews/new/facility_buttons',

--- a/app/views/facility_reviews/new/_facility_category.html.erb
+++ b/app/views/facility_reviews/new/_facility_category.html.erb
@@ -1,6 +1,6 @@
  <% if facilities_in_category.present? %>
   <%= tag.h3 category.title %>
-  <ul class="flex flex-col gap-8">
+  <ul class="flex flex-col gap-1">
     <% facilities_in_category.each do |facility_review| %>
       <%= render partial: 'facility_reviews/new/facility_buttons',
                  locals: {

--- a/app/views/spaces/edit/_facility_description.html.erb
+++ b/app/views/spaces/edit/_facility_description.html.erb
@@ -1,4 +1,0 @@
-<%= render partial: 'spaces/edit/common/edit_rich_text', locals: {
-  form: form,
-  field: :facility_description,
-} %>

--- a/app/views/spaces/show/_facilities.html.erb
+++ b/app/views/spaces/show/_facilities.html.erb
@@ -10,28 +10,28 @@
     <% end %>
   </header>
 
-  <main class="grid divide-y">
-    <% FacilityCategory.all.includes(:facilities).each do |facilityCategory| %>
-      <% next if @facilities_for_categories[facilityCategory.id].nil? %>
-      <div class="grid md:grid-cols-3 md:gap-4 items-baseline py-4 md:py-8">
-        <h3 class="no-mt">
-          <%= facilityCategory.title %>
-        </h3>
+  <% if @grouped_relevant_facilities.present? %>
+    <main class="grid divide-y">
+      <% @grouped_relevant_facilities.each do | group |  %>
+        <div class="grid md:grid-cols-3 md:gap-4 items-baseline py-4 md:py-8">
+          <h3 class="no-mt">
+            <%= group.second[:category].title %>
+          </h3>
 
-        <ul class="grid gap-1 md:col-span-2">
-          <% @facilities_for_categories[facilityCategory.id].each do |facility| %>
-            <%= render partial: 'spaces/show/facility_item', locals: {
-              title: facility[:title],
-              review: facility[:review],
-              description: facility[:description],
-              tooltip: t("tooltips.facility_aggregated_experience.#{facility[:review]}")
-            } %>
-          <% end %>
-        </ul>
-      </div>
-
-    <% end %>
-  </main>
+          <ul class="grid gap-1 md:col-span-2">
+            <% group.second[:space_facilities].each do |facility| %>
+              <%= render partial: 'spaces/show/facility_item', locals: {
+                title: facility[:title],
+                review: facility[:review],
+                description: facility[:description],
+                tooltip: t("tooltips.facility_aggregated_experience.#{facility[:review]}")
+              } %>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    </main>
+  <% end %>
 
   <aside>
     <%= modal_for :new_facility_review_path, "h-90vh modal--with-header-and-footer" do  %>

--- a/app/views/spaces/show/_facility_item.html.erb
+++ b/app/views/spaces/show/_facility_item.html.erb
@@ -7,9 +7,9 @@
     </span>
   </span>
   <% unless description.nil? %>
-    <p class="text-gray-400">
+    <div class="text-gray-400 mb-1.5">
       <%= description %>
-    </p>
+    </div>
   <% end %>
 
 </li>

--- a/app/views/spaces/show/_facility_item.html.erb
+++ b/app/views/spaces/show/_facility_item.html.erb
@@ -1,6 +1,6 @@
 <li
   title="<%= tooltip %>">
-  <span class="flex items-center gap-1.5">
+  <span class="flex items-center gap-1.5 <%= "line-through text-gray-600" if review == "impossible" %>">
     <%= title %>
       <span>
       <%= inline_svg_tag "facility_status/#{review}" %>

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -109,6 +109,11 @@ nb:
     update_success: "Bilde lagret"
     back_to_space: "Tilbake til %{title}"
   facility_reviews:
+    new:
+      showing_relevant_facilities: 'Viser kun fasiliteter som er spesielle for %{space_title} eller vanlige for lokaler av typen "%{space_types}".'
+      show_other_facilities:
+        one: 'Vis den siste fasiliteten'
+        other: 'Vis %{count} andre fasiliteter'
     edit: 'Redigér fasiliteter'
   reviews:
     add_review: 'Legg til erfaring'

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -22,16 +22,22 @@ nb:
     close_contact: "Lukk"
   tooltips:
     facility_single_experience:
-      was_allowed: 'Fikk lov'
-      was_not_allowed: 'Fikk ikke lov'
+      was_allowed: 'Fikk bruke'
+      was_not_allowed: 'Fikk ikke bruke'
       was_not_available: 'De har ikke'
       havent_asked: 'Ikke spurt'
     facility_aggregated_experience:
       unknown: 'Usikkert. Ingen har spurt!'
       impossible: 'Umulig. De har ikke.'
-      unlikely: 'Usannsynlig. Ingen eller få har fått lov'
-      maybe: 'Kanskje! Ikke alle får lov'
-      likely: 'Sannsynlig: Andre har fått lov!'
+      unlikely: 'Usannsynlig. Ingen eller få har fått bruke'
+      maybe: 'Kanskje! Ikke alle får bruke'
+      likely: 'Sannsynlig: Andre har fått bruke!'
+    others_experience:
+      unknown: 'Ingen har spurt'
+      impossible: 'De har ikke'
+      unlikely: 'Andre får ikke bruke'
+      maybe: 'Noen får bruke, andre ikke'
+      likely: 'Andre får bruke'
   address_search:
     no_address_given: 'Kart'
     didnt_find: 'Fant ikke adressen'

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -28,7 +28,7 @@ nb:
       havent_asked: 'Ikke spurt'
     facility_aggregated_experience:
       unknown: 'Usikkert. Ingen har spurt!'
-      impossible: 'Umulig. De har ikke.'
+      impossible: 'De har ikke.'
       unlikely: 'Usannsynlig. Ingen eller få har fått bruke'
       maybe: 'Kanskje! Ikke alle får bruke'
       likely: 'Sannsynlig: Andre har fått bruke!'

--- a/config/locales/simple_form.nb.yml
+++ b/config/locales/simple_form.nb.yml
@@ -61,6 +61,8 @@ nb:
       space_facility:
         description: "Beskrivelse"
         experience: "Min erfaring:"
+        review: "Andres erfaring"
+
       space_contact:
         title: "Navn"
         telephone: "Telefon"

--- a/config/locales/simple_form.nb.yml
+++ b/config/locales/simple_form.nb.yml
@@ -58,6 +58,9 @@ nb:
         organization_number: "Organisasjonsnummer"
         space_type_id: "Velg type lokale"
         space_group_title: "Lokalet har felles informasjon med:"
+      space_facility:
+        description: "Beskrivelse"
+        experience: "Min erfaring:"
       space_contact:
         title: "Navn"
         telephone: "Telefon"
@@ -66,6 +69,8 @@ nb:
         url: "Nettside"
         description: "Tilleggsinformasjon"
     placeholders:
+      space_facility:
+        description: "Legg til beskrivelse"
       space_contact:
         title: 'F.eks. "Rektor Ola Nordmann" eller "Sentralbord"'
         telephone: "Telefon"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   resources "space_groups", except: "new"
   resources "space_contacts", only: [:create, :edit, :update, :destroy, :show]
 
-  get "/facility_reviews/:space_id/new", to: "facility_reviews#new", as: "new_facility_review"
-  post "/facility_reviews/:space_id", to: "facility_reviews#create", as: "create_facility_review"
+  get "/spaces/:space_id/facility_review", to: "facility_reviews#new", as: "new_facility_review"
+  post "/spaces/:space_id/facility_review", to: "facility_reviews#create", as: "create_facility_review"
 
   # Review routes
   resources "reviews", except: "new"


### PR DESCRIPTION
Too large a PR, sorry about that.

This attempts to make facilities editable in a semi-sane way:

## Code changes

- [x] Extracts functions for listing relevant and non-relevant facilities for a space from the function to group those facilities, so I could re-use the 'relevant' and 'non-relevant' functions and so we no longer needed filter_matching_space_types, filter_not_matching_space_types. Replaces Space#facilities_for_categories. 

- [x] Also adjusts the functions for relevant and non-relevant facilities so :impossible states are treated equally as :unknown states. 

- [x] Complete rewrite of the Simulus controller  equal_checkboxes_handler so that it now handles both checkboxes, radios, and text inputs - making sure all content is synced between them. This allows us to list facilities (including the facility description) under multiple headings in the edit area. Controller renamed to 'sync_fields_with_same_id'

- [x] New Stimulus controller for controlling toggling of "hidden', for use when showing edit fields in the facility edit. Named hide_controller.

- [x] Changes aggregation for :impossible facility reviews to no longer need two reviews minimum to toggle as :impossible. This is to make it more intuitive and cleaner, and we no longer hide :impossible facilities that are relevant for a space type so its no longer needed to hedge against bad  user input hiding facilities forever.

- [x] Changes routing of facility_reviews to match the routing of reviews, with the space first in the url. New route is /spaces/:space_id/facility_review

## UI changes

### Strike through on :impossible and slightly adjusted margins for Space#show#facilities

![image](https://user-images.githubusercontent.com/14905290/154027590-8098acc8-fc1c-4c9c-a0dd-979f4cce0a89.png)


### Facilities editable inline

![image](https://user-images.githubusercontent.com/14905290/154027681-c7e6fc3f-c5e8-424d-95bc-3571dc3ecfaa.png)

![image](https://user-images.githubusercontent.com/14905290/154027724-888a6526-11a1-4824-8950-61c712c40448.png)


### Button for showing rest of facilities styled

And added a description for why some facilities are hidden.

![image](https://user-images.githubusercontent.com/14905290/154027765-f2852fd6-8e34-4eb7-820a-8905ead643a9.png)
