### PR TITLE
Fix overlap between footer and menu on mobile

### DIFF
--- a/app/views/layouts/menu/_menu.html.erb
+++ b/app/views/layouts/menu/_menu.html.erb
@@ -1,6 +1,6 @@
 <% if current_user %>
 <div
-    class="fixed bottom-0 md:top-0 md:bottom-auto w-full z-10 h-24 md:h-14"
+    class="fixed bottom-0 md:top-0 md:bottom-auto w-full z-20 h-24 md:h-14"
 >
     <nav
       class="flex justify-between h-full bg-white p-4 leading-none top-shadow-lg md:shadow-lg z-10">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/14905290/154235879-8eefa20b-e0dc-4891-8af7-c119aa5fcb76.png)


Now:

![image](https://user-images.githubusercontent.com/14905290/154235785-005eb242-9820-46d3-9578-658b2b694c98.png)
: