### PR TITLE
Fix n 1 problem in search

### DIFF
--- a/app/controllers/facility_reviews_controller.rb
+++ b/app/controllers/facility_reviews_controller.rb
@@ -26,6 +26,10 @@ class FacilityReviewsController < BaseControllers::AuthenticateController
       return
     end
 
+    # TODO: Aggregate only the changed or new facilities, not all
+    # That will require no longer deleting all in parse_facility_reviews, and thus updating,
+    # not creating, in FaclityReview.create. Otherwise, all you need to do is pass a facilities: [Faciliy]
+    # array to aggregate_facility_reviews.
     @space.aggregate_facility_reviews
 
     update_space_facilities

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -105,11 +105,14 @@ class Space < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # NOTE: this expects a scope for spaces but returns an array
   # preferably we would find some way to return a scope too
   def self.filter_on_facilities(spaces, filtered_facilities)
-    results = spaces.includes(space_facilities: [:facility]).filter_map do |space|
-      relevant_space_facilities = space.space_facilities.relevant
+    results = spaces.includes(space_facilities: [:facility])
+                    .where(space_facilities: { relevant: true })
+                    .filter_map do |space|
+      relevant_space_facilities = space.space_facilities
+      relevant_facility_ids = relevant_space_facilities.map { |sf| sf.facility.id }
 
       # If no relevant matches at all, exclude the space:
-      next unless (filtered_facilities & relevant_space_facilities.map { |sf| sf.facility.id }).any?
+      next unless (filtered_facilities & relevant_facility_ids).any?
 
       space.score_by_filter_on_facilities(filtered_facilities, relevant_space_facilities)
     end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -76,8 +76,8 @@ class Space < ApplicationRecord # rubocop:disable Metrics/ClassLength
       north_east: { lat: north_east_lat, lng: north_east_lng } }
   end
 
-  def aggregate_facility_reviews
-    Spaces::AggregateFacilityReviewsService.call(space: self)
+  def aggregate_facility_reviews(facilities: [])
+    Spaces::AggregateFacilityReviewsService.call(space: self, facilities: facilities)
   end
 
   def aggregate_star_rating

--- a/app/models/space_facility.rb
+++ b/app/models/space_facility.rb
@@ -2,6 +2,7 @@
 
 class SpaceFacility < ApplicationRecord
   enum experience: { unknown: 0, impossible: 1, unlikely: 2, maybe: 3, likely: 4 }
+
   belongs_to :facility
   belongs_to :space
 
@@ -10,6 +11,20 @@ class SpaceFacility < ApplicationRecord
   scope :in_category, lambda { |facility_category_id|
     joins(:facility).where("facility.facility_category_id": facility_category_id)
   }
+  scope :relevant, -> { where(relevant: true) }
+  scope :not_relevant, -> { where(relevant: false) }
+
+  def relevant!
+    update!(relevant: true)
+  end
+
+  def not_relevant!
+    update!(relevant: false)
+  end
+
+  def not_relevant?
+    !relevant?
+  end
 end
 
 # == Schema Information
@@ -19,6 +34,7 @@ end
 #  id          :bigint           not null, primary key
 #  description :string
 #  experience  :integer
+#  relevant    :boolean          default(FALSE)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  facility_id :bigint           not null

--- a/app/models/space_types_facility.rb
+++ b/app/models/space_types_facility.rb
@@ -3,6 +3,18 @@
 class SpaceTypesFacility < ApplicationRecord
   belongs_to :space_type
   belongs_to :facility
+
+  after_create do
+    space_type.reload.spaces.each do |space|
+      space.reload.aggregate_facility_reviews(facilities: [facility])
+    end
+  end
+
+  after_destroy do
+    space_type.reload.spaces.each do |space|
+      space.reload.aggregate_facility_reviews(facilities: [facility])
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/space_types_relation.rb
+++ b/app/models/space_types_relation.rb
@@ -3,6 +3,14 @@
 class SpaceTypesRelation < ApplicationRecord
   belongs_to :space_type
   belongs_to :space
+
+  after_save do
+    space.reload.aggregate_facility_reviews
+  end
+
+  after_destroy do
+    space.reload.aggregate_facility_reviews
+  end
 end
 
 # == Schema Information

--- a/app/services/spaces/aggregate_facility_reviews_service.rb
+++ b/app/services/spaces/aggregate_facility_reviews_service.rb
@@ -15,11 +15,11 @@ module Spaces
       # for a single aggregated review and we don't want to be hitting the DB for every 'experience' change
       SpaceFacility.transaction do
         facilities = Facility.all.order(:created_at).map do |facility|
-          SpaceFacility.new(experience: "unknown", space: space, facility: facility)
+          SpaceFacility.create(experience: "unknown", space: space, facility: facility)
         end
 
         facilities.each do |space_facility|
-          space_facility.save! if aggregate_reviews(space_facility).present?
+          aggregate_reviews(space_facility)
         end
       end
     end
@@ -27,32 +27,50 @@ module Spaces
     private
 
     def aggregate_reviews(space_facility) # rubocop:disable Metrics/AbcSize
-      reviews = space.facility_reviews.where(facility: space_facility.facility).order(created_at: :desc).limit(5)
+      facility = space_facility.facility
+      reviews = space.facility_reviews.where(facility: facility).order(created_at: :desc).limit(5)
       count = reviews.count
 
-      return handle_zero_facility_reviews(space, space_facility) if count.zero?
+      belongs_to_space_type = facility_belongs_to_space_type(facility)
+
+      return handle_zero_facility_reviews(space_facility, belongs_to_space_type) if count.zero?
 
       # Set criteria:
-      impossible_threshold = (count / 2.0).ceil
-      positive_threshold = (count / 3.0 * 2.0).ceil
-      negative_threshold = (count / 3.0 * 2.0).ceil
+      positive_threshold = reviews.positive.count >= (count / 3.0 * 2.0).ceil
+      impossible_threshold = reviews.impossible.count >= (count / 2.0).ceil
+      negative_threshold = reviews.negative.count >= (count / 3.0 * 2.0).ceil
 
-      return space_facility.impossible! if reviews.impossible.count >= impossible_threshold
-      return space_facility.likely! if  reviews.positive.count >= positive_threshold
-      return space_facility.unlikely! if reviews.negative.count >= negative_threshold
+      set_relevance(space_facility, belongs_to_space_type, positive_threshold)
 
-      # Nothing else fits, so it's a maybe!
-      space_facility.maybe!
+      set_experience(space_facility, positive_threshold, impossible_threshold, negative_threshold)
     end
 
-    def handle_zero_facility_reviews(space, space_facility)
-      space_types_with_relevant_facilities = space.space_types.filter do |space_type|
-        space_type.facilities.include? space_facility.facility
-      end
+    # NB: Does not set relevance for the maybe scenario, that is set in set_experience
+    def set_relevance(space_facility, belongs_to_space_type, positive_threshold)
+      return space_facility.not_relevant! unless positive_threshold || belongs_to_space_type
 
-      return nil if space_types_with_relevant_facilities.empty?
+      space_facility.relevant!
+    end
 
-      space_facility.unknown!
+    def set_experience(space_facility, positive_threshold, impossible_threshold, negative_threshold)
+      return space_facility.likely! if positive_threshold
+      return space_facility.impossible! if impossible_threshold
+      return space_facility.unlikely! if negative_threshold
+
+      # Nothing else fits, so it's a _relevant_ maybe!
+      space_facility.maybe! && space_facility.relevant!
+    end
+
+    def handle_zero_facility_reviews(space_facility, belongs_to_space_type)
+      return space_facility.unknown! && space_facility.not_relevant! unless belongs_to_space_type
+
+      space_facility.unknown! && space_facility.relevant!
+    end
+
+    def facility_belongs_to_space_type(facility)
+      space.space_types.filter do |space_type|
+        space_type.facilities.include? facility
+      end.any?
     end
 
     attr_reader :space

--- a/app/views/spaces/index/_search_form.html.erb
+++ b/app/views/spaces/index/_search_form.html.erb
@@ -12,23 +12,6 @@
     </div>
   </div>
 
-  <div class="my-8">
-    <h3 class="text-xl font-bold mt-4"><%= SpaceType.model_name.human(count: 2) %></h3>
-    <div class="mt-2">
-      <% SpaceType.all.each do |space_type| %>
-        <%= f.label space_type.type_name, class: "flex gap-2 my-1" do %>
-          <%=
-            f.check_box space_type.type_name,
-                        class: "h-5 w-5 text-lnu-pink focus:ring-lnu-pink border-gray-300 rounded",
-                        name: space_type.id,
-                        data: { mapbox_target: "spaceType" }
-          %>
-          <%= space_type.type_name %>
-        <% end %>
-      <% end %>
-    </div>
-  </div>
-
   <div  class="my-8">
     <h3 class="text-xl font-bold mt-4">
       <%= Facility.model_name.human(count: 2) %>
@@ -57,4 +40,22 @@
       <% end %>
     </div>
   </div>
+
+  <div class="my-8">
+    <h3 class="text-xl font-bold mt-4"><%= SpaceType.model_name.human(count: 2) %></h3>
+    <div class="mt-2">
+      <% SpaceType.all.each do |space_type| %>
+        <%= f.label space_type.type_name, class: "flex gap-2 my-1" do %>
+          <%=
+            f.check_box space_type.type_name,
+                        class: "h-5 w-5 text-lnu-pink focus:ring-lnu-pink border-gray-300 rounded",
+                        name: space_type.id,
+                        data: { mapbox_target: "spaceType" }
+          %>
+          <%= space_type.type_name %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
 <% end %>

--- a/app/views/spaces/index/_space_facility_listing.html.erb
+++ b/app/views/spaces/index/_space_facility_listing.html.erb
@@ -1,6 +1,6 @@
 <ul class="grid grid-cols-2 gap-2 mt-2">
   <% filtered_facilities.each do |facility| %>
-    <% next unless space.relevant_facilities.include?(facility) %>
+    <% next unless space.relevance_of_facility(facility) %>
     <% review = space.reviews_for_facility(facility) %>
     <%= render partial: 'spaces/show/facility_item', locals: {
       title: facility[:title],

--- a/db/migrate/20220217073115_add_relevant_integer_to_space_facility.rb
+++ b/db/migrate/20220217073115_add_relevant_integer_to_space_facility.rb
@@ -1,0 +1,5 @@
+class AddRelevantIntegerToSpaceFacility < ActiveRecord::Migration[6.1]
+  def change
+    add_column :space_facilities, :relevant, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_06_111257) do
+ActiveRecord::Schema.define(version: 2022_02_17_073115) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema.define(version: 2022_02_06_111257) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "description"
+    t.boolean "relevant", default: false
     t.index ["facility_id"], name: "index_space_facilities_on_facility_id"
     t.index ["space_id"], name: "index_space_facilities_on_space_id"
   end

--- a/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
+++ b/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
@@ -3,34 +3,38 @@
 require "rails_helper"
 
 RSpec.describe Spaces::AggregateFacilityReviewsService do
-  let(:space) { Fabricate(:space) }
+  let(:space_type) { Fabricate(:space_type) }
+  let(:space) { Fabricate(:space, space_types: [space_type]) }
   let(:facility_category) { Fabricate(:facility_category) }
-  let(:facility) { Fabricate(:facility, facility_categories: [facility_category]) }
+  let(:facility) { Fabricate(:facility, facility_categories: [facility_category], space_types: [space_type]) }
 
   def experience(experience, other_facility = nil)
     Fabricate(:facility_review, space: space, experience: experience, facility: other_facility || facility)
     space.reload.aggregate_facility_reviews
   end
 
-  it "turns into maybe if there are mixed reviews" do
+  it "turns into a relevant maybe if there are mixed reviews" do
     experience :was_allowed
     experience :was_not_allowed
     expect(space.reload.reviews_for_facility(facility)).to eq("maybe")
+    expect(space.reload.relevance_of_facility(facility)).to eq(true)
   end
 
-  it "turns into likely if there are over 2/3 positive reviews" do
+  it "turns into a relevant likely if there are over 2/3 positive reviews" do
     experience :was_not_allowed
     3.times { experience :was_allowed }
     expect(space.reload.reviews_for_facility(facility)).to eq("likely")
+    expect(space.reload.relevance_of_facility(facility)).to eq(true)
   end
 
   it "turns into likely if there are over 2/3 positive reviews, even if those are only the last five" do
     10.times { experience :was_not_allowed }
     4.times { experience :was_allowed }
     expect(space.reload.reviews_for_facility(facility)).to eq("likely")
+    expect(space.reload.relevance_of_facility(facility)).to eq(true)
   end
 
-  it "turns into impossible if half or more say it does not exist (out of a minimum of 2)" do
+  it "turns into impossible if half or more say it does not exist" do
     experience :was_not_allowed
     experience :was_not_available
     experience :was_not_available
@@ -63,5 +67,54 @@ RSpec.describe Spaces::AggregateFacilityReviewsService do
       experience :was_allowed, Fabricate(:facility)
     end
     expect(space.reload.reviews_for_facility(facility)).to eq("maybe")
+    expect(space.reload.relevance_of_facility(facility)).to eq(true)
+  end
+
+  it "Is set as relevant if in space_type, even if impossible or negative or unknown" do
+    experience :was_not_available
+    expect(space.reload.relevance_of_facility(facility)).to eq(true)
+
+    space.facility_reviews.destroy_all
+    space.aggregate_facility_reviews
+
+    experience :was_not_allowed
+    expect(space.reload.relevance_of_facility(facility)).to eq(true)
+
+    space.facility_reviews.destroy_all
+    space.aggregate_facility_reviews
+
+    expect(space.reload.relevance_of_facility(facility)).to eq(true)
+  end
+
+  it "is set as irrelevant if negative or impossible and not in space_type" do
+    non_space_type_facility = Fabricate(:facility, space_types: [Fabricate(:space_type)])
+
+    experience :was_not_available, non_space_type_facility
+    expect(space.reload.relevance_of_facility(non_space_type_facility)).to eq(false)
+
+    space.facility_reviews.destroy_all
+    space.aggregate_facility_reviews
+
+    experience :was_not_allowed, non_space_type_facility
+    expect(space.reload.relevance_of_facility(non_space_type_facility)).to eq(false)
+
+    space.facility_reviews.destroy_all
+    space.aggregate_facility_reviews
+
+    expect(space.reload.relevance_of_facility(non_space_type_facility)).to eq(false)
+  end
+
+  it "is set as relevant if a positive or maybe, even if it's not in the space type" do
+    non_space_type_facility = Fabricate(:facility, space_types: [Fabricate(:space_type)])
+
+    experience :was_allowed, non_space_type_facility
+
+    expect(space.reload.reviews_for_facility(non_space_type_facility)).to eq("likely")
+    expect(space.reload.relevance_of_facility(non_space_type_facility)).to eq(true)
+
+    experience :was_not_allowed, non_space_type_facility
+
+    expect(space.reload.reviews_for_facility(non_space_type_facility)).to eq("maybe")
+    expect(space.reload.relevance_of_facility(non_space_type_facility)).to eq(true)
   end
 end

--- a/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
+++ b/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Spaces::AggregateFacilityReviewsService do
 
     expect(space.reload.relevance_of_facility(other_facility)).to eq(true)
 
-    other_facility.update!(space_types: [])
+    space_type.update!(facilities: [facility])
 
     expect(space.reload.relevance_of_facility(other_facility)).to eq(false)
   end

--- a/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
+++ b/spec/services/spaces/aggregate_facility_reviews_service_spec.rb
@@ -117,4 +117,44 @@ RSpec.describe Spaces::AggregateFacilityReviewsService do
     expect(space.reload.reviews_for_facility(non_space_type_facility)).to eq("maybe")
     expect(space.reload.relevance_of_facility(non_space_type_facility)).to eq(true)
   end
+
+  it "sets relevance if a facility is added to a Spaces space type" do
+    other_facility = Fabricate(:facility, space_types: [Fabricate(:space_type)])
+
+    expect(space.reload.relevance_of_facility(other_facility)).to eq(false)
+
+    other_facility.update!(space_types: [space_type])
+
+    expect(space.reload.relevance_of_facility(other_facility)).to eq(true)
+  end
+
+  it "removes relevance if a facility is removed from a Spaces space type" do
+    other_facility = Fabricate(:facility, space_types: [space_type])
+
+    expect(space.reload.relevance_of_facility(other_facility)).to eq(true)
+
+    other_facility.update!(space_types: [])
+
+    expect(space.reload.relevance_of_facility(other_facility)).to eq(false)
+  end
+
+  it "sets relevance if a Space Type is added to a space" do
+    new_space_type = Fabricate(:space_type)
+
+    other_facility = Fabricate(:facility, space_types: [new_space_type])
+
+    expect(space.reload.relevance_of_facility(other_facility)).to eq(false)
+
+    space.update!(space_types: [new_space_type])
+
+    expect(space.reload.relevance_of_facility(other_facility)).to eq(true)
+  end
+
+  it "removes relevance if a Space Type is removed from a Space" do
+    expect(space.reload.relevance_of_facility(facility)).to eq(true)
+
+    space.update!(space_types: [])
+
+    expect(space.reload.relevance_of_facility(facility)).to eq(false)
+  end
 end


### PR DESCRIPTION
- [x] Make fixing of n+1 problem feasible by creating .relevant boolean on space_facility, and setting it while aggregating
- [x] Create tests for .relevant
- [x] Fix n+1 problem
- [x] Run aggregation for relevant facilities and spaces when space_type for a space changes 
- [x] Run aggregation for relevant facilities and spaces when facility for a space_type changes

Two changes should be done to improve the feel of the app, but can be done in future PRs:

- [ ] Defer aggregation on changing space types <> facility with sidekiq, as it might trigger an aggregation of thousands of spaces and makes changing space_type facilities very slow indeed.
- [ ] Only aggregate for changed facilities on updating facility reviews as it currently takes _for_ever_ to save faciliity reivews. (Also a problem in main, not specific to this PR)