### PR TITLE
Quicker aggregation

### DIFF
--- a/app/controllers/facility_reviews_controller.rb
+++ b/app/controllers/facility_reviews_controller.rb
@@ -19,18 +19,17 @@ class FacilityReviewsController < BaseControllers::AuthenticateController
 
   def create
     @space = Space.find(params["space_id"])
-    parsed = parse_facility_reviews(params["facility_reviews"]["reviews"])
+    affected_facility_ids = []
+
+    parsed = parse_facility_reviews(params["facility_reviews"]["reviews"], affected_facility_ids)
 
     unless FacilityReview.create(parsed)
       render :new, status: :unprocessable_entity
       return
     end
 
-    # TODO: Aggregate only the changed or new facilities, not all
-    # That will require no longer deleting all in parse_facility_reviews, and thus updating,
-    # not creating, in FaclityReview.create. Otherwise, all you need to do is pass a facilities: [Faciliy]
-    # array to aggregate_facility_reviews.
-    @space.aggregate_facility_reviews
+    affected_facilities = Facility.where(id: affected_facility_ids.uniq)
+    @space.aggregate_facility_reviews(facilities: affected_facilities)
 
     update_space_facilities
 
@@ -68,29 +67,47 @@ class FacilityReviewsController < BaseControllers::AuthenticateController
 
   private
 
-  def parse_facility_reviews(facility_reviews)
+  def parse_facility_reviews(raw_data, affected_facility_ids)
     # Converting to .values exists solely because I didn't manage to create a
     # form with radio buttons that sent the facility_reviews in a way that could
     # be automatically picked up by Rails AND still be seen as individual in the form itself.
     # Thus, we have to parse what is sent from the form here into something
     # that more closely resembles what the model expects:
     # Changes welcome!
-    facility_review_values = facility_reviews.values
+    facility_reviews = raw_data.values
 
-    delete_all_previous_reviews facility_review_values
+    handle_changed(facility_reviews, affected_facility_ids)
   end
 
-  # This should be done in the model, but I never figured out how.
-  # I tried to .destroy and filter on before_validation, but
-  # it only got roll-backed.
-  def delete_all_previous_reviews(facility_reviews)
-    ids = facility_reviews.filter_map do |review|
-      review["id"] unless review["id"].empty?
+  # Does two things:
+  # 1. Destroys any existing reviews that are changed, and returns an array of new reviews to be created
+  # 2. And mutates affected_facilities so we can aggregate facilities for those
+  def handle_changed(facility_reviews, affected_facility_ids) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    facility_reviews.filter_map do |review|
+      # We minimum need these to do anything useful
+      next unless review[:user_id].present? && review[:facility_id].present? && review[:space_id].present?
+
+      existing_review = FacilityReview.find_by(user_id: review[:user_id],
+                                               facility_id: review[:facility_id],
+                                               space_id: review[:space_id])
+
+      # NB: Unknown experiences do not crate reviews. Thus existing_review.blank? is the same as
+      # experience == "unknown"
+      nothing_changed = (existing_review.blank? && review["experience"] == "unknown") ||
+                        (existing_review.present? && existing_review[:experience] == review["experience"])
+
+      next if nothing_changed
+
+      # Something changed, so add facility to affected facilities
+      affected_facility_ids << review["facility_id"]
+
+      # Destroy the old review, so we are ready to return a new review for creation.
+      existing_review.destroy if existing_review.present?
+
+      # Unknown experiences do not crate reviews.
+      next if review["experience"] == "unknown"
+
+      review
     end
-
-    FacilityReview.where(id: ids).destroy_all
-
-    facility_reviews.delete_if { |review| review["experience"] == "unknown" }
-    facility_reviews
   end
 end

--- a/app/models/space_types_relation.rb
+++ b/app/models/space_types_relation.rb
@@ -5,11 +5,11 @@ class SpaceTypesRelation < ApplicationRecord
   belongs_to :space
 
   after_save do
-    space.reload.aggregate_facility_reviews
+    space.reload.aggregate_facility_reviews(facilities: space_type.facilities)
   end
 
   after_destroy do
-    space.reload.aggregate_facility_reviews
+    space.reload.aggregate_facility_reviews(facilities: space_type.facilities)
   end
 end
 

--- a/app/services/spaces/aggregate_facility_reviews_service.rb
+++ b/app/services/spaces/aggregate_facility_reviews_service.rb
@@ -30,19 +30,30 @@ module Spaces
       # Start a transaction because we may be modifying the 'experience' field many times
       # for a single aggregated review and we don't want to be hitting the DB for every 'experience' change
       SpaceFacility.transaction do
-        Facility.all.order(:created_at).each do |facility|
-          aggregate_reviews(facility)
+        facility_reviews = space.facility_reviews.includes(:facility)
+        facilities_with_reviews = facility_reviews.map(&:facility)
+        facilities_from_space_type = space.space_types.includes(:facilities).map(&:facilities).flatten
+
+        aggregate_individually = [*facilities_with_reviews, *facilities_from_space_type].uniq.sort_by(&:created_at)
+        aggregate_in_bulk = Facility.all.where.not(id: aggregate_individually.map(&:id))
+
+        aggregate_individually.each do |facility|
+          space_facility = SpaceFacility.create_or_find_by(space: @space, facility: facility)
+          aggregate_reviews(facility, space_facility, facility_reviews, facilities_from_space_type)
+        end
+
+        aggregate_in_bulk.each do |facility|
+          space_facility = SpaceFacility.create_or_find_by(space: @space, facility: facility)
+          space_facility.unknown! && space_facility.not_relevant!
         end
       end
     end
 
-    def aggregate_reviews(facility) # rubocop:disable Metrics/AbcSize
-      space_facility = SpaceFacility.find_or_create_by(space: @space, facility: facility)
-
-      reviews = space.facility_reviews.where(facility: facility).order(created_at: :desc).limit(5)
+    def aggregate_reviews(facility, space_facility, facility_reviews, facilities_from_space_type) # rubocop:disable Metrics/AbcSize
+      reviews = facility_reviews.where(facility: facility).order(created_at: :desc).limit(5)
       count = reviews.count
 
-      belongs_to_space_type = facility_belongs_to_space_type(facility)
+      belongs_to_space_type = facilities_from_space_type.include?(facility)
 
       return handle_zero_facility_reviews(space_facility, belongs_to_space_type) if count.zero?
 
@@ -76,12 +87,6 @@ module Spaces
       return space_facility.unknown! && space_facility.not_relevant! unless belongs_to_space_type
 
       space_facility.unknown! && space_facility.relevant!
-    end
-
-    def facility_belongs_to_space_type(facility)
-      space.space_types.filter do |space_type|
-        space_type.facilities.include? facility
-      end.any?
     end
 
     attr_reader :space


### PR DESCRIPTION
(Made this just to see if I could! Not billable hours for me)

This should cut aggregation time to 1/3 for aggregating facilities for all spaces, and make it near instant when adding facility reviews for a space.

Should be tested a bit as it touches core functions, and unfortunately it seems like our test coverage of facility reviews is fairly low.

This branch: 

- [x] Makes it quicker to run aggregation by cutting SQL queries in half and making the ruby code more effective too in `AggregateFacilityReviewsService`. There is probably more to gain, but it at least cuts it by 2/3!

And uses the ability in AggregateFacilityReviewsService to add a list of facilities to run to only aggregate relevant facilities for the following cases: 

- [x] When a new space type is removed or added to a space, we now only run aggregation for facilities relevant to that space type
- [x] When a new facility is added or removed from a space type, we only run aggregation for that facility 
- [x] When a new facility review is added or changed or removed from a space, we only run aggregation for the facilities relevant for that review

All in all this means that the UX is now much smoother when doing things that trigger aggregation.

Not tackled in this branch
- [ ] Off-loading aggregation to a sidekiq background job when we don't need it to be complete before the next page load (for example when adding facilities to space types)