### PR TITLE
Statistics for administrators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,11 @@ gem "omniauth-rails_csrf_protection"
 gem "activerecord-import"
 gem "activerecord-postgis-adapter" # For PostGIS and Geo commands in Active record
 gem "addressable"
+gem "chartkick" # Charts
 gem "cssbundling-rails"
 gem "diffy"
 gem "gravtastic"
+gem "groupdate" # for grouping models by date
 gem "high_voltage"
 gem "http"
 gem "inline_svg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
       addressable
       capybara
       playwright-ruby-client (>= 1.16.0)
+    chartkick (5.1.2)
     childprocess (5.1.0)
       logger (~> 1.5)
     choice (0.2.0)
@@ -177,6 +178,8 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     gravtastic (3.2.6)
+    groupdate (6.5.1)
+      activesupport (>= 7)
     guard (2.19.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -567,6 +570,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-playwright-driver
+  chartkick
   cssbundling-rails
   devise (~> 4.9)
   devise-i18n
@@ -576,6 +580,7 @@ DEPENDENCIES
   faker
   foreman
   gravtastic
+  groupdate
   guard
   guard-livereload
   guard-rspec

--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -145,6 +145,10 @@
     @apply border border-gray-300 placeholder-gray-500 text-gray-900 ;
     @apply focus:outline-none focus:border-lnu-pink  focus:ring-lnu-pink;
   }
+  .select_field {
+    @extend .text_field;
+    @apply pr-8;
+  }
   .file_field {
     @apply w-full text-gray-500 px-3 py-2 border rounded;
     @extend .focused-outline;

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Admin
-  class DashboardController < BaseControllers::AuthenticateAsAdminController
+  class DashboardController < BaseControllers::AuthenticateAsAdminController # rubocop:disable Metrics/ClassLength:
     PERIODS_TO_GROUP_BY = %i[
       hour
       day
@@ -31,15 +31,38 @@ module Admin
       @changes_created_by_system = PaperTrail::Version
                                    .where(whodunnit: nil)
                                    .group_by_period(@period_grouping, :created_at, range: @date_range).count
+      @changes_created_by_system_count = PaperTrail::Version
+                                         .where(created_at: @date_range)
+                                         .where(whodunnit: nil)
+                                         .count
+
+      user_changes_from_paper_trail
+      most_users_creating_changes
+    end
+
+    def user_changes_from_paper_trail
       @changes_created_by_users = PaperTrail::Version
                                   .where.not(whodunnit: nil)
                                   .group_by_period(@period_grouping, :created_at, range: @date_range).count
+      @changes_created_by_users_count = PaperTrail::Version
+                                        .where(created_at: @date_range)
+                                        .where.not(whodunnit: nil)
+                                        .count
+
       @unique_users_creating_changes = PaperTrail::Version
                                        .where.not(whodunnit: nil)
                                        .group_by_period(@period_grouping, :created_at,
                                                         range: @date_range)
                                        .distinct
                                        .count(:whodunnit)
+      @unique_users_creating_changes_count = PaperTrail::Version
+                                             .where(created_at: @date_range)
+                                             .where.not(whodunnit: nil)
+                                             .distinct
+                                             .count(:whodunnit)
+    end
+
+    def most_users_creating_changes
       @most_changes_per_user = PaperTrail::Version
                                .where(created_at: @date_range)
                                .where.not(whodunnit: nil)
@@ -52,23 +75,29 @@ module Admin
 
     def space_statistics
       @spaces_created = Space.group_by_period(@period_grouping, :created_at, range: @date_range).count
+      @spaces_created_count = Space.where(created_at: @date_range).count
+      @space_count = Space.count
     end
 
     def review_statistics
       @reviews_created = Review.group_by_period(@period_grouping, :created_at, range: @date_range).count
+      @reviews_created_count = Review.where(created_at: @date_range).count
     end
 
     def facility_review_statistics
       @facility_reviews_created = FacilityReview.group_by_period(@period_grouping, :created_at,
                                                                  range: @date_range).count
+      @facility_reviews_created_count = FacilityReview.where(created_at: @date_range).count
     end
 
     def user_statistics
       @users_created = User.group_by_period(@period_grouping, :created_at, range: @date_range).count
+      @users_created_count = User.where(created_at: @date_range).count
     end
 
     def list_statistics
       @lists_created = PersonalSpaceList.group_by_period(@period_grouping, :created_at, range: @date_range).count
+      @lists_created_count = PersonalSpaceList.where(created_at: @date_range).count
     end
 
     def set_period_grouping

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,6 +2,91 @@
 
 module Admin
   class DashboardController < BaseControllers::AuthenticateAsAdminController
-    def index; end
+    PERIODS_TO_GROUP_BY = %i[
+      hour
+      day
+      week
+      month
+      year
+    ].freeze
+    def index
+      set_date_range
+      set_period_grouping
+
+      statistics
+    end
+
+    private
+
+    def statistics
+      paper_trail_statistics
+      space_statistics
+      review_statistics
+      facility_review_statistics
+      user_statistics
+      list_statistics
+    end
+
+    def paper_trail_statistics
+      @changes_created = PaperTrail::Version.group_by_period(@period_grouping, :created_at, range: @date_range).count
+      @unique_users_creating_changes = PaperTrail::Version.group_by_period(@period_grouping, :created_at,
+                                                                           range: @date_range).count(:whodunnit)
+      @most_changes_per_user = PaperTrail::Version
+                               .where(created_at: @date_range)
+                               .where.not(whodunnit: nil)
+                               .group(:whodunnit)
+                               .count
+                               .sort_by { |_, count| count }
+                               .reverse
+    end
+
+    def space_statistics
+      @spaces_created = Space.group_by_period(@period_grouping, :created_at, range: @date_range).count
+    end
+
+    def review_statistics
+      @reviews_created = Review.group_by_period(@period_grouping, :created_at, range: @date_range).count
+    end
+
+    def facility_review_statistics
+      @facility_reviews_created = FacilityReview.group_by_period(@period_grouping, :created_at,
+                                                                 range: @date_range).count
+    end
+
+    def user_statistics
+      @users_created = User.group_by_period(@period_grouping, :created_at, range: @date_range).count
+    end
+
+    def list_statistics
+      @lists_created = PersonalSpaceList.group_by_period(@period_grouping, :created_at, range: @date_range).count
+    end
+
+    def set_period_grouping
+      @period_grouping = params.permit("period_grouping")[:period_grouping].presence || default_period_grouping
+    end
+
+    def default_period_grouping
+      days_of_stats_shown = @date_range.count
+
+      case days_of_stats_shown
+      when 0
+        :hour
+      when 1..31
+        :day
+      when 32..200
+        :week
+      when 201..720
+        :month
+      else
+        :year
+      end
+    end
+
+    def set_date_range
+      start_date = params[:start_date]&.to_date || 1.year.ago.to_date
+      end_date = params[:end_date]&.to_date || Date.current
+
+      @date_range = start_date..end_date
+    end
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -21,8 +21,10 @@ module Admin
     def statistics
       paper_trail_statistics
       space_statistics
+      space_fields_statistics
       review_statistics
       facility_review_statistics
+      space_facility_statistics
       user_statistics
       list_statistics
     end
@@ -30,6 +32,7 @@ module Admin
     def paper_trail_statistics
       @changes_created_by_system = PaperTrail::Version
                                    .where(whodunnit: nil)
+                                   .group("item_type")
                                    .group_by_period(@period_grouping, :created_at, range: @date_range).count
       @changes_created_by_system_count = PaperTrail::Version
                                          .where(created_at: @date_range)
@@ -43,6 +46,7 @@ module Admin
     def user_changes_from_paper_trail
       @changes_created_by_users = PaperTrail::Version
                                   .where.not(whodunnit: nil)
+                                  .group("item_type")
                                   .group_by_period(@period_grouping, :created_at, range: @date_range).count
       @changes_created_by_users_count = PaperTrail::Version
                                         .where(created_at: @date_range)
@@ -79,20 +83,95 @@ module Admin
       @space_count = Space.count
     end
 
+    def space_fields_statistics # rubocop:disable Metrics/AbcSize
+      @spaces_with_title = Space.where.not(title: nil).count
+      @spaces_with_image = Space.includes(:images).where.not(images: { id: nil }).count
+      @spaces_with_facility_reviews = Space.includes(:facility_reviews).where.not(facility_reviews: { id: nil }).count
+      @spaces_with_reviews = Space.includes(:reviews).where.not(reviews: { id: nil }).count
+      @spaces_with_space_contacts = Space.includes(:space_contacts).where.not(space_contacts: { id: nil }).count
+      @spaces_with_space_group = Space.includes(:space_group).where.not(space_group: { id: nil }).count
+      @spaces_with_space_type = Space.includes(:space_types).where.not(space_types: { id: nil }).count
+      @spaces_with_address = Space.where.not(address: nil).count
+      @spaces_with_fylke = Space.where.not(fylke_id: nil).count
+      @spaces_with_lat_lng = Space.where.not(lat: nil).count
+      @spaces_with_location_description = Space.where.not(location_description: [nil, ""]).count
+      @spaces_in_a_list = Space.joins(:personal_space_lists).distinct.count
+      @spaces_with_how_to_book = spaces_with_rich_text("how_to_book")
+      @spaces_with_who_can_use = spaces_with_rich_text("who_can_use")
+      @spaces_with_pricing = spaces_with_rich_text("pricing")
+      @spaces_with_terms = spaces_with_rich_text("terms")
+      @spaces_with_more_info = spaces_with_rich_text("more_info")
+    end
+
     def review_statistics
-      @reviews_created = Review.group_by_period(@period_grouping, :created_at, range: @date_range).count
+      @reviews_created = Review
+                         .group("type_of_contact")
+                         .group_by_period(@period_grouping, :created_at, range: @date_range).count
       @reviews_created_count = Review.where(created_at: @date_range).count
     end
 
     def facility_review_statistics
-      @facility_reviews_created = FacilityReview.group_by_period(@period_grouping, :created_at,
-                                                                 range: @date_range).count
+      @facility_reviews_created = FacilityReview
+                                  .group("experience")
+                                  .group_by_period(@period_grouping, :created_at,
+                                                   range: @date_range).count
       @facility_reviews_created_count = FacilityReview.where(created_at: @date_range).count
     end
 
-    def user_statistics
-      @users_created = User.group_by_period(@period_grouping, :created_at, range: @date_range).count
+    def space_facility_statistics
+      @relevant_space_facilities_count = SpaceFacility.where(relevant: true).count
+      @relevant_space_facilities_with_known_experience = SpaceFacility
+                                                         .where(relevant: true)
+                                                         .where.not(experience: :unknown)
+                                                         .count
+    end
+
+    def user_statistics # rubocop:disable Metrics/AbcSize, Metrics/MethodLength:
+      top_organizations = User
+                          .where(created_at: @date_range)
+                          .group(:organization)
+                          .count.sort_by { |_, count| -count }
+                          .take(6).filter(&:last).map(&:first)
+
+      sql_for_gropuing_by_organization = Arel.sql(
+        <<~SQL.squish
+          CASE
+            WHEN organization = '' THEN 'Ingen organisasjon'
+            WHEN organization IN (
+              #{top_organizations.map do |org|
+                "'#{org}'"
+              end.join(',')}
+              ) THEN organization
+            ELSE 'Annen organisasjon'
+          END
+        SQL
+      )
+
+      @users_created = User
+                       .group(sql_for_gropuing_by_organization)
+                       .group_by_period(
+                         @period_grouping,
+                         :created_at,
+                         range: @date_range
+                       ).count
+
       @users_created_count = User.where(created_at: @date_range).count
+      @users_count = User.count
+      @users_with_reviews = User.joins(:reviews)
+                                .where.not(reviews: { id: nil })
+                                .distinct.count
+      @users_with_facility_reviews = User.joins(:facility_reviews)
+                                         .where.not(facility_reviews: { id: nil })
+                                         .distinct.count
+      @users_with_organization = User.where.not(organization: [nil, ""]).count
+      @users_with_first_name = User.where.not(first_name: [nil, ""]).count
+      @users_with_last_name = User.where.not(last_name: [nil, ""]).count
+      @admin_users = User.where(admin: true).count
+      @organizations_with_user_count = User
+                                       .group(:organization)
+                                       .count
+                                       .sort_by { |_, count| -count }
+      @organizations_to_show_before_expanding_list = 5
     end
 
     def list_statistics
@@ -126,6 +205,10 @@ module Admin
       end_date = params[:end_date]&.to_date || Date.current
 
       @date_range = start_date..end_date
+    end
+
+    def spaces_with_rich_text(field)
+      Space.joins(:"rich_text_#{field}").where.not(action_text_rich_texts: { body: [nil, ""] }).count
     end
   end
 end

--- a/app/controllers/admin/menu_controller.rb
+++ b/app/controllers/admin/menu_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Admin
+  class MenuController < BaseControllers::AuthenticateAsAdminController
+    def index; end
+  end
+end

--- a/app/controllers/base_controllers/authenticate_as_admin_controller.rb
+++ b/app/controllers/base_controllers/authenticate_as_admin_controller.rb
@@ -3,6 +3,7 @@
 module BaseControllers
   class AuthenticateAsAdminController < AuthenticateController
     before_action :authenticate_admin!
+    layout "admin/authenticated_as_admin"
 
     protected
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,6 +6,9 @@ import * as ActiveStorage from "@rails/activestorage"
 import "./channels"
 import "./controllers"
 
+// Charts
+import "chartkick/chart.js"
+
 // Posthog for tracking
 import "./custom/posthog"
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,6 @@
 
 class User < ApplicationRecord
   require "securerandom"
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:google_oauth2]

--- a/app/views/admin/dashboard/_statistics_box.html.erb
+++ b/app/views/admin/dashboard/_statistics_box.html.erb
@@ -1,5 +1,5 @@
-<%# locals: (header:) %>
-<section class="bg-white p-6 rounded-lg shadow-2xl">
+<%# locals: (header:, append_css_classes: "") %>
+<section class="bg-white p-6 rounded-lg shadow-2xl <%= append_css_classes %>">
   <h2 class="text-lnu-blue font-bold mb-4 text-center">
     <%= header %>
   </h2>

--- a/app/views/admin/dashboard/_statistics_box.html.erb
+++ b/app/views/admin/dashboard/_statistics_box.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (header:) %>
+<section class="bg-white p-6 rounded-lg shadow-2xl">
+  <h2 class="text-lnu-blue font-bold mb-4 text-center">
+    <%= header %>
+  </h2>
+  <%= yield %>
+</section>

--- a/app/views/admin/dashboard/_tiny_pie_chart.html.erb
+++ b/app/views/admin/dashboard/_tiny_pie_chart.html.erb
@@ -1,0 +1,21 @@
+<%# locals: (with:, total:, text:) %>
+<span class="flex gap-2 items-center" title="<%= with %> har, <%= total - with %> har ikke">
+  <%= pie_chart(
+        {
+          "Har": with,
+          "Har ikke": total - with
+        },
+          colors: ["#C40066", "#C4006610"],
+          dataset: { borderWidth: 0 },
+          legend: { display: false },
+          library: { plugins: {tooltip: {enabled: false }}},
+          width: "20px",
+        height: "20px"
+
+      ) %>
+  <span>
+     <%= number_with_delimiter with %>
+     <%= text %>
+     <span class="text-gray-500">(<%= number_to_percentage((with * 100 / total)) %>)</span>
+  </span>
+</span>

--- a/app/views/admin/dashboard/_user_with_change_count.html.erb
+++ b/app/views/admin/dashboard/_user_with_change_count.html.erb
@@ -1,0 +1,10 @@
+<%# locals: (user:, count:) %>
+<li class="flex gap-2 items-center">
+  <div class="flex-shrink-0">
+    <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
+  </div>
+  <div class="text-sm">
+    <strong><%= user.name %></strong>  (<%= count %> endringer)<br>
+    <%= user.email %><% if user.organization.present? %>, <%= user.organization %><% end %>
+  </div>
+</li>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,94 +1,381 @@
-<header class="pt-8 px-4 max-w-prose mx-auto w-screen">
+<h1 class="font-bold text-lnu-blue mb-8 sr-only">Statistikk</h1>
 
-  <h1 class="font-bold text-lnu-blue mb-8 sr-only">Statistikk</h1>
+<div class="grid grid-cols-1 items-baseline justify-items-center 4xl:grid-cols-2 gap-8 p-8 max-w-screen-4xl mx-auto">
 
-  <%= form_tag admin_dashboard_index_path, method: :get do %>
-    <div class="flex flex-col gap-4 p-4 -mx-4 bg-gray-50 rounded-lg border border-gray-200">
-      <div class="flex gap-8 items-center justify-between">
-        <fieldset class="flex gap-2 items-center">
-          <legend class="sr-only">Datoer</legend>
-          <label for="start_date" class="label">Fra</label>
-          <%= date_field_tag :start_date, params[:start_date] || @date_range.first, class: 'text_field' %>
-          <label for="end_date" class="label">til</label>
-          <%= date_field_tag :end_date, params[:end_date] || @date_range.last,  class: 'text_field' %>
-        </fieldset>
-        <fieldset class="flex gap-2 items-center">
-          <label for="period" class="label">Per</label>
-          <%= select_tag :period_grouping, options_for_select(
-            [
-              *Admin::DashboardController::PERIODS_TO_GROUP_BY.map { |period| [t("date_periods.#{period}"), period] }
-            ],
-              @period_grouping
-            ), class: "select_field" %>
-        </fieldset>
-        <%= submit_tag "Filtrer", class: "button" %>
-      </div>
-    </div>
-  <% end %>
-</header>
+<section class="bg-gray-50 p-4 rounded-lg border border-gray-200 w-full max-w-screen-2xl">
+  <header class="mb-8 pt-4 max-w-prose mx-auto w-screen">
 
-<main class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 w-screen p-12 max-w-screen-2xl mx-auto">
-
-  <%= render "admin/dashboard/statistics_box",
-             header: "Brukere med flest endringer" do %>
-    <ul class="flex gap-2 flex-col">
-      <% @most_changes_per_user.first(@most_changes_per_user_limit).map do |user_id, count| %>
-        <% user = User.find(user_id) %>
-        <%= render "admin/dashboard/user_with_change_count", user:, count:  %>
-      <% end %>
-    </ul>
-    <% if @most_changes_per_user.count > @most_changes_per_user_limit %>
-      <details>
-        <summary class="link my-4">Og <%= @most_changes_per_user.count - @most_changes_per_user_limit %> flere</summary>
-        <ul class="flex gap-2 flex-col">
-          <% @most_changes_per_user.drop(@most_changes_per_user_limit).map do |user_id, count| %>
-            <% user = User.find(user_id) %>
-            <%= render "admin/dashboard/user_with_change_count", user:, count: %>
-        <% end %>
-        </ul>
-      </details>
+    <h2 class="text-center uppercase text-lnu-blue/90 font-normal tracking-wider text-sm">Filtrert på dato</h2>
+    <%= form_tag admin_dashboard_index_path, method: :get do %>
+      <nav class="flex flex-col gap-3 p-4 -mx-4">
+        <div class="flex gap-8 items-center">
+          <fieldset class="flex gap-2 items-center">
+            <legend class="sr-only">Datoer</legend>
+            <label for="start_date" class="label">Fra</label>
+            <%= date_field_tag :start_date, params[:start_date] || @date_range.first, class: 'text_field' %>
+            <label for="end_date" class="label">til</label>
+            <%= date_field_tag :end_date, params[:end_date] || @date_range.last,  class: 'text_field' %>
+          </fieldset>
+          <fieldset class="flex gap-2 items-center">
+            <label for="period" class="label">Per</label>
+            <%= select_tag :period_grouping, options_for_select(
+              [
+                *Admin::DashboardController::PERIODS_TO_GROUP_BY.map { |period| [t("date_periods.#{period}"), period] }
+              ],
+                @period_grouping
+              ), class: "select_field" %>
+          </fieldset>
+          <%= submit_tag "Filtrer", class: "button" %>
+        </div>
+      </nav>
     <% end %>
-  <% end %>
+  </header>
 
-  <%= render "admin/dashboard/statistics_box",
-             header: "#{@unique_users_creating_changes_count} brukere med loggførte endringer" do %>
-    <%= column_chart @unique_users_creating_changes %>
-  <% end %>
+  <main class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 max-w-screen-2xl mx-auto">
 
-  <%= render "admin/dashboard/statistics_box",
-             header: "#{@changes_created_by_users_count} brukerinitierte loggførte endringer" do %>
-    <%= column_chart @changes_created_by_users %>
-  <% end %>
+    <%= render "admin/dashboard/statistics_box",
+               append_css_classes: "lg:col-span-2",
+               header: "#{@unique_users_creating_changes_count} brukere med loggførte endringer" do %>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-12">
+        <section>
+          <%= column_chart @unique_users_creating_changes, label: "Brukere" %>
+        </section>
+        <section>
+          <ul class="flex gap-2 flex-col">
+            <% @most_changes_per_user.first(@most_changes_per_user_limit).map do |user_id, count| %>
+              <% user = User.find(user_id) %>
+              <%= render "admin/dashboard/user_with_change_count", user:, count:  %>
+            <% end %>
+          </ul>
+          <% if @most_changes_per_user.count > @most_changes_per_user_limit %>
+            <details>
+              <summary class="link my-4">Og <%= @most_changes_per_user.count - @most_changes_per_user_limit %> flere</summary>
+              <ul class="flex gap-2 flex-col">
+                <% @most_changes_per_user.drop(@most_changes_per_user_limit).map do |user_id, count| %>
+                  <% user = User.find(user_id) %>
+                  <%= render "admin/dashboard/user_with_change_count", user:, count: %>
+                <% end %>
+              </ul>
+            </details>
+          <% end %>
+        </section>
+      </div>
 
-  <%= render "admin/dashboard/statistics_box",
-             header: "#{@changes_created_by_system_count} systeminitierte loggførte endringer" do %>
-    <%= column_chart @changes_created_by_system %>
-  <% end %>
+    <% end %>
 
-  <%= render "admin/dashboard/statistics_box",
-             header: "#{@users_created_count} nye brukere" do %>
-    <%= column_chart @users_created %>
-  <% end %>
+    <% colors_for_stacked_charts = ["#C40066", "#618467", "#175278", "#C4006630", "#61846730", "#17527830"] %>
 
-  <%= render "admin/dashboard/statistics_box",
-             header: "#{@spaces_created_count} nye lokaler" do %>
-    <%= column_chart @spaces_created %>
-  <% end %>
+    <%= render "admin/dashboard/statistics_box",
+               header: "#{number_with_delimiter @changes_created_by_users_count} brukerinitierte loggførte endringer" do %>
+      <%= column_chart @changes_created_by_users, label: "Endringer", stacked: true, colors: colors_for_stacked_charts %>
+    <% end %>
 
-  <%= render "admin/dashboard/statistics_box",
-             header: "#{@facility_reviews_created_count} nye fasilitetserfaringer" do %>
-    <%= column_chart @facility_reviews_created %>
-  <% end %>
+    <%= render "admin/dashboard/statistics_box",
+               header: "#{number_with_delimiter @changes_created_by_system_count} systeminitierte loggførte endringer" do %>
+      <%= column_chart @changes_created_by_system, label: "Endringer", stacked: true, colors: colors_for_stacked_charts %>
+    <% end %>
 
-  <%= render "admin/dashboard/statistics_box",
-             header: "#{@reviews_created_count} nye anmeldelser" do %>
-    <%= column_chart @reviews_created %>
-  <% end %>
+    <%= render "admin/dashboard/statistics_box",
+               header: "#{number_with_delimiter @users_created_count} nye brukere" do %>
+      <%= column_chart @users_created, label: "Nye brukere", stacked: true, colors: colors_for_stacked_charts %>
+    <% end %>
 
-  <%= render "admin/dashboard/statistics_box",
-             header: "#{@lists_created_count} nye lister" do %>
-    <%= column_chart @lists_created %>
-  <% end %>
-</main>
+    <%= render "admin/dashboard/statistics_box",
+               header: "#{number_with_delimiter @spaces_created_count} nye lokaler" do %>
+      <%= column_chart @spaces_created, label: "Nye lokaler" %>
+    <% end %>
+
+    <%= render "admin/dashboard/statistics_box",
+               header: "#{number_with_delimiter @facility_reviews_created_count} nye fasilitetserfaringer" do %>
+      <%= column_chart @facility_reviews_created, label: "Nye fasilitetserfaringer", stacked: true, colors: colors_for_stacked_charts %>
+    <% end %>
+
+    <%= render "admin/dashboard/statistics_box",
+               header: "#{number_with_delimiter @reviews_created_count} nye anmeldelser" do %>
+      <%= column_chart @reviews_created, label: "Nye anmeldelser", stacked: true, colors: colors_for_stacked_charts %>
+    <% end %>
+
+    <%= render "admin/dashboard/statistics_box",
+               header: "#{number_with_delimiter @lists_created_count} nye lister" do %>
+      <%= column_chart @lists_created, label: "Nye lister" %>
+    <% end %>
+  </main>
+</section>
+
+<section class="bg-gray-50 p-4 rounded-lg border border-gray-200 w-full  max-w-screen-2xl">
+  <header class="mb-8 pt-4 max-w-prose mx-auto w-screen">
+    <h2 class="text-center uppercase text-lnu-blue/90 font-normal tracking-wider text-sm">Øyeblikksbilde (ikke filtrert)</h2>
+  </header>
+
+  <main class="flex flex-col gap-4 max-w-screen-2xl mx-auto">
+    <%= render "admin/dashboard/statistics_box",
+               header: "Alle #{number_with_delimiter @space_count} lokaler" do %>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 mx-auto">
+      <section>
+        <h3 class="mt-4 mb-1 text-lnu-blue">Informasjon</h3>
+
+        <ul class="flex flex-col gap-1">
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_title,
+                     total: @space_count,
+                     text: "har tittel"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_image,
+                     total: @space_count,
+                     text: "har bilde"
+            %>
+          </li>
+
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_space_contacts,
+                     total: @space_count,
+                     text: "har kontaktperson"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_how_to_book,
+                     total: @space_count,
+                     text: "har tekst om hvordan booke"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_who_can_use,
+                     total: @space_count,
+                     text: "har tekst om hvem som kan bruke"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_pricing,
+                     total: @space_count,
+                     text: "har tekst om pris"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_terms,
+                     total: @space_count,
+                     text: "har tekst om vilkår"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_more_info,
+                     total: @space_count,
+                     text: "har tekst med mer info"
+            %>
+          </li>
+        </ul>
+      </section>
 
 
+      <section>
+        <h3 class="mt-4 mb-1 text-lnu-blue">Tilbakemeldinger</h3>
+        <ul class="flex flex-col gap-1">
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_facility_reviews,
+                     total: @space_count,
+                     text: "lokaler har fasilitetserfaring(er)"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_reviews,
+                     total: @space_count,
+                     text: "lokaler har anmeldelse(r)"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @relevant_space_facilities_with_known_experience,
+                     total: @relevant_space_facilities_count,
+                     text: "av #{number_with_delimiter(@relevant_space_facilities_count)} relevante fasiliteter har en erfaring"
+            %>
+          </li>
+        </ul>
+      </section>
+
+
+        <section>
+        <h3 class="mt-4 mb-1 text-lnu-blue">Tilhørlighet</h3>
+        <ul class="flex flex-col gap-1">
+          <li>
+            <%= render "admin/dashboard/tiny_pie_chart",
+                       with: @spaces_in_a_list,
+                       total: @space_count,
+                       text: "er lagt i noens liste"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_space_group,
+                     total: @space_count,
+                     text: "tilhører en gruppe"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_space_type,
+                     total: @space_count,
+                     text: "har en space type"
+            %>
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h3 class="mt-4 mb-1 text-lnu-blue">Geodata</h3>
+        <ul class="flex flex-col gap-1">
+
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_lat_lng,
+                     total: @space_count,
+                     text: "har lokasjon (lat/lng)"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_address,
+                     total: @space_count,
+                     text: "har en adresse"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_fylke,
+                     total: @space_count,
+                     text: "har et fylke i Norge"
+            %>
+          </li>
+          <li>
+            <%=
+              render "admin/dashboard/tiny_pie_chart",
+                     with: @spaces_with_location_description,
+                     total: @space_count,
+                     text: "har en lokasjonsbeskrivelse"
+            %>
+          </li>
+        </ul>
+      </section>
+      </div>
+    <% end %>
+
+    <%= render "admin/dashboard/statistics_box",
+               header: "Alle #{number_with_delimiter @users_count} brukere" do %>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 mx-auto">
+        <section>
+          <h3 class="mt-4 mb-1 text-lnu-blue">Brukerdata</h3>
+
+          <ul class="flex flex-col gap-1">
+            <li>
+              <%=
+                render "admin/dashboard/tiny_pie_chart",
+                       with: @users_with_organization,
+                       total: @users_count,
+                       text: "har organisasjon"
+              %>
+            </li>
+            <li>
+              <%=
+                render "admin/dashboard/tiny_pie_chart",
+                       with: @users_with_first_name,
+                       total: @users_count,
+                       text: "har fornavn"
+              %>
+            </li>
+            <li>
+              <%=
+                render "admin/dashboard/tiny_pie_chart",
+                       with: @users_with_last_name,
+                       total: @users_count,
+                       text: "har etternavn"
+              %>
+            </li>
+          </ul>
+        </section>
+
+
+        <section>
+          <h3 class="mt-4 mb-1 text-lnu-blue">Brukere med tilbakemeldinger</h3>
+          <ul class="flex flex-col gap-1">
+            <li>
+              <%=
+                render "admin/dashboard/tiny_pie_chart",
+                       with: @users_with_reviews,
+                       total: @users_count,
+                       text: "har lagt inn anmeldelse(r)"
+              %>
+            </li>
+            <li>
+              <%=
+                render "admin/dashboard/tiny_pie_chart",
+                       with: @users_with_facility_reviews,
+                       total: @users_count,
+                       text: "har lagt inn fasilitetserfaring(er)"
+              %>
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h3 class="mt-4 mb-1 text-lnu-blue">Organisasjoner</h3>
+          <ol class="list-decimal list-inside">
+            <% @organizations_with_user_count.first(@organizations_to_show_before_expanding_list).each do |organization, count| %>
+              <li>
+                <%= organization.presence || "Ingen definert" %> <span class="text-gray-500">(<%= count %> brukere)</span>
+              </li>
+            <% end %>
+          </ol>
+          <% if @organizations_with_user_count.count > @organizations_to_show_before_expanding_list %>
+            <details>
+              <summary class="link my-4">
+                Vis <%= @organizations_with_user_count.count - @organizations_to_show_before_expanding_list %> flere
+              </summary>
+              <ol start="<%= @organizations_to_show_before_expanding_list + 1 %>" class="list-decimal list-inside">
+                <% @organizations_with_user_count.drop(@organizations_to_show_before_expanding_list).each do |organization, count| %>
+                  <li>
+                    <%= organization.presence || "Ingen definert" %> <span class="text-gray-500">(<%= count %> brukere)</span>
+                  </li>
+                <% end %>
+              </ol>
+            </details>
+          <% end %>
+        </section>
+      </div>
+    <% end %>
+
+
+  </main>
+
+</section>
+
+
+
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -31,7 +31,7 @@
   <section class="bg-white p-6 rounded-lg shadow-2xl">
     <h2 class="text-lnu-blue font-bold mb-4 text-center">Brukere med flest endringer</h2>
     <ul class="flex gap-2 flex-col">
-      <% @most_changes_per_user.first(5).map do |user_id, count| %>
+      <% @most_changes_per_user.first(@most_changes_per_user_limit).map do |user_id, count| %>
         <% user = User.find(user_id) %>
         <li class="flex gap-2 items-center">
           <div class="flex-shrink-0">
@@ -44,19 +44,24 @@
         </li>
       <% end %>
     </ul>
-    <% if @most_changes_per_user.count > 10 %>
-      <p>Og <%= @most_changes_per_user.count - 10 %> flere</p>
+    <% if @most_changes_per_user.count > @most_changes_per_user_limit %>
+      <p>Og <%= @most_changes_per_user.count - @most_changes_per_user_limit %> flere</p>
     <% end %>
   </section>
 
   <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Antall brukere med endringer i endringslogg</h2>
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Brukere med loggførte endringer</h2>
     <%= column_chart @unique_users_creating_changes %>
   </section>
 
   <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Endringer i endringslogg</h2>
-    <%= column_chart @changes_created %>
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Brukerinitierte loggførte endringer</h2>
+    <%= column_chart @changes_created_by_users %>
+  </section>
+
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Systeminitierte loggførte endringer</h2>
+    <%= column_chart @changes_created_by_system %>
   </section>
 
   <section class="bg-white p-6 rounded-lg shadow-2xl">

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -38,27 +38,29 @@
             <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
           </div>
           <div class="text-sm">
-            <strong><%= user.name %></strong> (<%= user.email %>)<br>
-            <%= count %> endringer
+            <strong><%= user.name %></strong>  (<%= count %> endringer)<br>
+            <%= user.email %><% if user.organization.present? %><%= user.organization %>, <% end %>
           </div>
         </li>
       <% end %>
     </ul>
     <% if @most_changes_per_user.count > @most_changes_per_user_limit %>
-      <details class="mt-2">
-        <summary>Og <%= @most_changes_per_user.count - @most_changes_per_user_limit %> flere</summary>
-        <% @most_changes_per_user.drop(@most_changes_per_user_limit).map do |user, count| %>
-          <% user = User.find(user_id) %>
-          <li class="flex gap-2 items-center">
-            <div class="flex-shrink-0">
-              <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
-            </div>
-            <div class="text-sm">
-              <strong><%= user.name %></strong> (<%= user.email %>)<br>
-              <%= count %> endringer
-            </div>
-          </li>
-        <% end %>
+      <details>
+        <summary class="link my-4">Og <%= @most_changes_per_user.count - @most_changes_per_user_limit %> flere</summary>
+        <ul class="flex gap-2 flex-col">
+          <% @most_changes_per_user.drop(@most_changes_per_user_limit).map do |user_id, count| %>
+            <% user = User.find(user_id) %>
+            <li class="flex gap-2 items-center">
+              <div class="flex-shrink-0">
+                <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
+              </div>
+              <div class="text-sm">
+                <strong><%= user.name %></strong> (<%= user.email %>)<br>
+                <%= count %> endringer
+              </div>
+            </li>
+          <% end %>
+        </ul>
       </details>
     <% end %>
   </section>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -45,7 +45,21 @@
       <% end %>
     </ul>
     <% if @most_changes_per_user.count > @most_changes_per_user_limit %>
-      <p>Og <%= @most_changes_per_user.count - @most_changes_per_user_limit %> flere</p>
+      <details class="mt-2">
+        <summary>Og <%= @most_changes_per_user.count - @most_changes_per_user_limit %> flere</summary>
+        <% @most_changes_per_user.drop(@most_changes_per_user_limit).map do |user, count| %>
+          <% user = User.find(user_id) %>
+          <li class="flex gap-2 items-center">
+            <div class="flex-shrink-0">
+              <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
+            </div>
+            <div class="text-sm">
+              <strong><%= user.name %></strong> (<%= user.email %>)<br>
+              <%= count %> endringer
+            </div>
+          </li>
+        <% end %>
+      </details>
     <% end %>
   </section>
 

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -28,20 +28,13 @@
 </header>
 
 <main class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 w-screen p-12 max-w-screen-2xl mx-auto">
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Brukere med flest endringer</h2>
+
+  <%= render "admin/dashboard/statistics_box",
+             header: "Brukere med flest endringer" do %>
     <ul class="flex gap-2 flex-col">
       <% @most_changes_per_user.first(@most_changes_per_user_limit).map do |user_id, count| %>
         <% user = User.find(user_id) %>
-        <li class="flex gap-2 items-center">
-          <div class="flex-shrink-0">
-            <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
-          </div>
-          <div class="text-sm">
-            <strong><%= user.name %></strong>  (<%= count %> endringer)<br>
-            <%= user.email %><% if user.organization.present? %><%= user.organization %>, <% end %>
-          </div>
-        </li>
+        <%= render "admin/dashboard/user_with_change_count", user:, count:  %>
       <% end %>
     </ul>
     <% if @most_changes_per_user.count > @most_changes_per_user_limit %>
@@ -50,60 +43,52 @@
         <ul class="flex gap-2 flex-col">
           <% @most_changes_per_user.drop(@most_changes_per_user_limit).map do |user_id, count| %>
             <% user = User.find(user_id) %>
-            <li class="flex gap-2 items-center">
-              <div class="flex-shrink-0">
-                <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
-              </div>
-              <div class="text-sm">
-                <strong><%= user.name %></strong> (<%= user.email %>)<br>
-                <%= count %> endringer
-              </div>
-            </li>
-          <% end %>
+            <%= render "admin/dashboard/user_with_change_count", user:, count: %>
+        <% end %>
         </ul>
       </details>
     <% end %>
-  </section>
+  <% end %>
 
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Brukere med loggførte endringer</h2>
+  <%= render "admin/dashboard/statistics_box",
+             header: "#{@unique_users_creating_changes_count} brukere med loggførte endringer" do %>
     <%= column_chart @unique_users_creating_changes %>
-  </section>
+  <% end %>
 
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Brukerinitierte loggførte endringer</h2>
+  <%= render "admin/dashboard/statistics_box",
+             header: "#{@changes_created_by_users_count} brukerinitierte loggførte endringer" do %>
     <%= column_chart @changes_created_by_users %>
-  </section>
+  <% end %>
 
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Systeminitierte loggførte endringer</h2>
+  <%= render "admin/dashboard/statistics_box",
+             header: "#{@changes_created_by_system_count} systeminitierte loggførte endringer" do %>
     <%= column_chart @changes_created_by_system %>
-  </section>
+  <% end %>
 
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye brukere</h2>
+  <%= render "admin/dashboard/statistics_box",
+             header: "#{@users_created_count} nye brukere" do %>
     <%= column_chart @users_created %>
-  </section>
+  <% end %>
 
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye lokaler</h2>
+  <%= render "admin/dashboard/statistics_box",
+             header: "#{@spaces_created_count} nye lokaler" do %>
     <%= column_chart @spaces_created %>
-  </section>
+  <% end %>
 
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye fasilitetserfaringer</h2>
+  <%= render "admin/dashboard/statistics_box",
+             header: "#{@facility_reviews_created_count} nye fasilitetserfaringer" do %>
     <%= column_chart @facility_reviews_created %>
-  </section>
+  <% end %>
 
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye anmeldelser</h2>
+  <%= render "admin/dashboard/statistics_box",
+             header: "#{@reviews_created_count} nye anmeldelser" do %>
     <%= column_chart @reviews_created %>
-  </section>
+  <% end %>
 
-  <section class="bg-white p-6 rounded-lg shadow-2xl">
-    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye lister</h2>
-    <%= column_chart @lists_created  %>
-  </section>
+  <%= render "admin/dashboard/statistics_box",
+             header: "#{@lists_created_count} nye lister" do %>
+    <%= column_chart @lists_created %>
+  <% end %>
 </main>
 
 

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,6 +1,6 @@
-<main class="py-8 px-4 max-w-prose mx-auto w-screen">
+<header class="pt-8 px-4 max-w-prose mx-auto w-screen">
 
-  <h1 class="font-bold text-lnu-blue mb-8">Statistikk</h1>
+  <h1 class="font-bold text-lnu-blue mb-8 sr-only">Statistikk</h1>
 
   <%= form_tag admin_dashboard_index_path, method: :get do %>
     <div class="flex flex-col gap-4 p-4 -mx-4 bg-gray-50 rounded-lg border border-gray-200">
@@ -25,62 +25,64 @@
       </div>
     </div>
   <% end %>
+</header>
 
-  <main class="flex flex-col gap-8 divide-y divide-gray-200">
-    <section>
-      <h2 class="font-bold mt-8 mb-2">Endringer i endringslogg</h2>
-      <%= column_chart @changes_created, ytitle: "Endringer" %>
-    </section>
-
-    <section>
-      <h2 class="font-bold mt-8 mb-2">Antall brukere med endringer i endringslogg</h2>
-      <%= column_chart @unique_users_creating_changes, ytitle: "Brukere" %>
-    </section>
-
-    <section>
-      <h3 class="font-bold mt-8 mb-2">Brukere med flest endringer</h3>
-      <% @most_changes_per_user.first(10).map do |user_id, count| %>
+<main class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 w-screen p-12 max-w-screen-2xl mx-auto">
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Brukere med flest endringer</h2>
+    <ul class="flex gap-2 flex-col">
+      <% @most_changes_per_user.first(5).map do |user_id, count| %>
         <% user = User.find(user_id) %>
-        <div class="flex gap-2 items-center">
+        <li class="flex gap-2 items-center">
           <div class="flex-shrink-0">
             <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
           </div>
-          <div>
-            <strong><%= user.email %></strong>
+          <div class="text-sm">
+            <strong><%= user.name %></strong> (<%= user.email %>)<br>
             <%= count %> endringer
           </div>
-        </div>
+        </li>
       <% end %>
-      <% if @most_changes_per_user.count > 10 %>
-        <p>Og <%= @most_changes_per_user.count - 10 %> flere</p>
-      <% end %>
-    </section>
+    </ul>
+    <% if @most_changes_per_user.count > 10 %>
+      <p>Og <%= @most_changes_per_user.count - 10 %> flere</p>
+    <% end %>
+  </section>
 
-    <section>
-      <h2 class="font-bold mt-8 mb-2">Nye brukere</h2>
-      <%= column_chart @users_created, ytitle: "Brukere" %>
-    </section>
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Antall brukere med endringer i endringslogg</h2>
+    <%= column_chart @unique_users_creating_changes %>
+  </section>
 
-    <section>
-      <h2 class="font-bold mt-8 mb-2">Nye lokaler</h2>
-      <%= column_chart @spaces_created, ytitle: "Lokaler" %>
-    </section>
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Endringer i endringslogg</h2>
+    <%= column_chart @changes_created %>
+  </section>
 
-    <section>
-      <h2 class="font-bold mt-8 mb-2">Nye fasilitetserfaringer</h2>
-      <%= column_chart @facility_reviews_created, ytitle: "Fasilitetserfaringer" %>
-    </section>
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye brukere</h2>
+    <%= column_chart @users_created %>
+  </section>
 
-    <section>
-      <h2 class="font-bold mt-8 mb-2">Nye anmeldelser</h2>
-      <%= column_chart @reviews_created, ytitle: "Anmeldelser" %>
-    </section>
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye lokaler</h2>
+    <%= column_chart @spaces_created %>
+  </section>
 
-    <section>
-      <h2 class="font-bold mt-8 mb-2">Nye lister</h2>
-      <%= column_chart @lists_created, ytitle: "Lister" %>
-    </section>
-  </main>
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye fasilitetserfaringer</h2>
+    <%= column_chart @facility_reviews_created %>
+  </section>
 
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye anmeldelser</h2>
+    <%= column_chart @reviews_created %>
+  </section>
 
+  <section class="bg-white p-6 rounded-lg shadow-2xl">
+    <h2 class="text-lnu-blue font-bold mb-4 text-center">Nye lister</h2>
+    <%= column_chart @lists_created  %>
+  </section>
 </main>
+
+

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,7 +1,86 @@
-<main class="content max-w-prose mx-auto w-screen">
+<main class="py-8 px-4 max-w-prose mx-auto w-screen">
 
-    <h1>Admin-verktøy:</h1>
-    <p><%= link_to t('admin.space_type'), admin_space_types_path %></p>
-    <p><%= link_to t('admin.history'), admin_history_index_path %></p>
+  <h1 class="font-bold text-lnu-blue mb-8">Statistikk</h1>
+
+  <%= form_tag admin_dashboard_index_path, method: :get do %>
+    <div class="flex flex-col gap-4 p-4 -mx-4 bg-gray-50 rounded-lg border border-gray-200">
+      <div class="flex gap-8 items-center justify-between">
+        <fieldset class="flex gap-2 items-center">
+          <legend class="sr-only">Datoer</legend>
+          <label for="start_date" class="label">Fra</label>
+          <%= date_field_tag :start_date, params[:start_date] || @date_range.first, class: 'text_field' %>
+          <label for="end_date" class="label">til</label>
+          <%= date_field_tag :end_date, params[:end_date] || @date_range.last,  class: 'text_field' %>
+        </fieldset>
+        <fieldset class="flex gap-2 items-center">
+          <label for="period" class="label">Per</label>
+          <%= select_tag :period_grouping, options_for_select(
+            [
+              *Admin::DashboardController::PERIODS_TO_GROUP_BY.map { |period| [t("date_periods.#{period}"), period] }
+            ],
+              @period_grouping
+            ), class: "select_field" %>
+        </fieldset>
+        <%= submit_tag "Filtrer", class: "button" %>
+      </div>
+    </div>
+  <% end %>
+
+  <main class="flex flex-col gap-8 divide-y divide-gray-200">
+    <section>
+      <h2 class="font-bold mt-8 mb-2">Endringer i endringslogg</h2>
+      <%= column_chart @changes_created, ytitle: "Endringer" %>
+    </section>
+
+    <section>
+      <h2 class="font-bold mt-8 mb-2">Antall brukere med endringer i endringslogg</h2>
+      <%= column_chart @unique_users_creating_changes, ytitle: "Brukere" %>
+    </section>
+
+    <section>
+      <h3 class="font-bold mt-8 mb-2">Brukere med flest endringer</h3>
+      <% @most_changes_per_user.first(10).map do |user_id, count| %>
+        <% user = User.find(user_id) %>
+        <div class="flex gap-2 items-center">
+          <div class="flex-shrink-0">
+            <%= image_tag user.gravatar_url(size: 25), class: "rounded-full" %>
+          </div>
+          <div>
+            <strong><%= user.email %></strong>
+            <%= count %> endringer
+          </div>
+        </div>
+      <% end %>
+      <% if @most_changes_per_user.count > 10 %>
+        <p>Og <%= @most_changes_per_user.count - 10 %> flere</p>
+      <% end %>
+    </section>
+
+    <section>
+      <h2 class="font-bold mt-8 mb-2">Nye brukere</h2>
+      <%= column_chart @users_created, ytitle: "Brukere" %>
+    </section>
+
+    <section>
+      <h2 class="font-bold mt-8 mb-2">Nye lokaler</h2>
+      <%= column_chart @spaces_created, ytitle: "Lokaler" %>
+    </section>
+
+    <section>
+      <h2 class="font-bold mt-8 mb-2">Nye fasilitetserfaringer</h2>
+      <%= column_chart @facility_reviews_created, ytitle: "Fasilitetserfaringer" %>
+    </section>
+
+    <section>
+      <h2 class="font-bold mt-8 mb-2">Nye anmeldelser</h2>
+      <%= column_chart @reviews_created, ytitle: "Anmeldelser" %>
+    </section>
+
+    <section>
+      <h2 class="font-bold mt-8 mb-2">Nye lister</h2>
+      <%= column_chart @lists_created, ytitle: "Lister" %>
+    </section>
+  </main>
+
 
 </main>

--- a/app/views/admin/menu/_admin_boxed_menu.html.erb
+++ b/app/views/admin/menu/_admin_boxed_menu.html.erb
@@ -1,0 +1,7 @@
+<div class="my-8 -mx-6 p-6 bg-lnu-blue/10  rounded-lg">
+  <h2 class="no-mt">
+    Adminverktøy
+  </h2>
+  <p class="opacity-80">Du er administrator.</p>
+  <%= render "admin/menu/admin_menu" %>
+</div>

--- a/app/views/admin/menu/_admin_menu.html.erb
+++ b/app/views/admin/menu/_admin_menu.html.erb
@@ -1,0 +1,4 @@
+
+<ul class="list-disc list-inside">
+  <%= render "admin/menu/admin_menu_items" %>
+</ul>

--- a/app/views/admin/menu/_admin_menu_item.html.erb
+++ b/app/views/admin/menu/_admin_menu_item.html.erb
@@ -1,0 +1,10 @@
+<%#
+
+    Locals:
+    - path: Path to link to
+    - text: Text to show
+
+%>
+<%= link_to path, class: "#{active_path?(path) ? "text-gray-900 font-bold hover:decoration-none" : "text-lnu-pink hover:underline"}" do %>
+    <%= text %>
+<% end %>

--- a/app/views/admin/menu/_admin_menu_items.html.erb
+++ b/app/views/admin/menu/_admin_menu_items.html.erb
@@ -1,0 +1,3 @@
+<li><%= render "admin/menu/admin_menu_item", text: t('admin.dashboard'), path: admin_dashboard_index_path %></li>
+<li><%= render "admin/menu/admin_menu_item", text: t('admin.history'), path: admin_history_index_path %></li>
+<li><%= render "admin/menu/admin_menu_item", text: t('admin.space_type'), path: admin_space_types_path %></li>

--- a/app/views/admin/menu/index.html.erb
+++ b/app/views/admin/menu/index.html.erb
@@ -1,0 +1,3 @@
+<main class="content max-w-prose mx-auto p-4">
+  <%= render "admin/menu/admin_boxed_menu" %>
+</main>

--- a/app/views/devise/sessions/edit.html.erb
+++ b/app/views/devise/sessions/edit.html.erb
@@ -21,5 +21,7 @@
     <%= link_to t('session.my_experiences'),
                 reviews_path %>
   </p>
-
+  <% if current_user.admin? %>
+    <%= render "admin/menu/admin_boxed_menu" %>
+  <% end %>
 </div>

--- a/app/views/layouts/admin/authenticated_as_admin.html.erb
+++ b/app/views/layouts/admin/authenticated_as_admin.html.erb
@@ -1,0 +1,12 @@
+<% content_for :above_body do %>
+  <nav class="flex justify-center p-4 gap-3 gap-6 flex-wrap items-baseline
+  bg-lnu-blue/10 text-sm">
+    <h2 class="text-lnu-blue uppercase text-xs font-bold tracking-wide">
+      <%= link_to "Admin", admin_root_path, class: "unstyled-link" %>
+    </h2>
+    <ul class="flex flex-wrap gap-3 md:gap-6 items-baseline">
+      <%= render "admin/menu/admin_menu_items" %>
+    </ul>
+  </nav>
+<% end %>
+<%= render template: "layouts/application" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     </div>
     <%= render partial: "layouts/menu/menu" %>
     <main class="flex-1">
+      <%= yield :above_body %>
       <%= yield %>
     </main>
     <footer class="<%= "md:sr-only" if controller_name == 'spaces' && action_name == 'index' %> px-2 pt-4 mt-4 pb-4 bg-gray-100">

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Chartkick.options = {
+  colors: ["#C40066"]
+}

--- a/config/locales/admin.nb.yml
+++ b/config/locales/admin.nb.yml
@@ -5,5 +5,6 @@ nb:
     event: 'Hendelse'
     changes: 'Endringer'
     changed_at: 'Endringstidspunkt'
-    history: Historikk
+    history: Endringshistorikk
     space_type: Type lokaler
+    dashboard: Statistikk

--- a/config/locales/date_periods.nb.yml
+++ b/config/locales/date_periods.nb.yml
@@ -1,0 +1,7 @@
+nb:
+  date_periods:
+    hour: time
+    day: dag
+    week: uke
+    month: måned
+    year: år

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   # Admin routes
   namespace "admin" do
-    root to: "dashboard#index"
+    root to: "menu#index"
+    resources :dashboard, only: [:index]
     resources "history"
     resources "space_types"
     post "history/revert_changes", to: "history#revert_changes"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@rails/activestorage": "^7.2.2",
     "@rails/ujs": "^7.1.3-4",
     "@splidejs/splide": "^4.1.4",
+    "chart.js": "^4.4.6",
+    "chartkick": "^5.0.1",
     "dotenv": "^16.4.5",
     "esbuild-rails": "^1.0.7",
     "mapbox-gl": "^3.8.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,7 @@ module.exports = {
             screens: {
                 'xs': '360px',
                 '3xl': '1792px',
+                '4xl': '2560px',
                 'any-hover': {'raw': 'media (any-hover: hover)'}
             },
             cursor: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,6 +602,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@mapbox/jsonlint-lines-primitives@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
@@ -1009,6 +1014,27 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chart.js@4, chart.js@^4.4.6:
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.4.6.tgz#da39b84ca752298270d4c0519675c7659936abec"
+  integrity sha512-8Y406zevUPbbIBA/HRk33khEmQPk5+cxeflWE/2rx1NJsjVWMPw/9mSP9rxHP5eqi6LNoPBVMfZHxbwLSgldYA==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
+
+chartjs-adapter-date-fns@>=3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz#c25f63c7f317c1f96f9a7c44bd45eeedb8a478e5"
+  integrity sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==
+
+chartkick@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-5.0.1.tgz#f557ff8560f974343dc65c7fc34ce1e8326d8ee7"
+  integrity sha512-4F3tWI3eBQgnjCYZIZ+fHOaJuNyxeyhDE2Tm+voOWB19hDjSJceys/spzN52DOn8bWepNESGXvPVTGU1jeFsbA==
+  optionalDependencies:
+    chart.js "4"
+    chartjs-adapter-date-fns ">=3"
+    date-fns ">=2"
+
 cheap-ruler@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cheap-ruler/-/cheap-ruler-4.0.0.tgz#bdc984de7e0e3f748bdfd2dbe23ec6b9dc820a09"
@@ -1146,6 +1172,11 @@ data-view-byte-offset@^1.0.0:
     call-bind "^1.0.6"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
+
+date-fns@>=2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
 debug@^3.2.7:
   version "3.2.7"


### PR DESCRIPTION
Adds a simple admin menu in the profile page for admins:

![CleanShot 2024-11-22 at 12 39 13](https://github.com/user-attachments/assets/b14dae3d-044b-428d-b57c-e7f50e1d8e85)

And a statistics page with filterable numbers from the database: 

![CleanShot 2024-11-22 at 12 40 13](https://github.com/user-attachments/assets/d16e9d1c-219f-41ee-8807-d05eaca11806)

Currently does not integrate with Posthogs tracking of visitors, but we might want to track visitors and use that for conversion rates. 