### PR TITLE
Remove params.permit calls that did nothing

### DIFF
--- a/app/controllers/concerns/define_facility_params.rb
+++ b/app/controllers/concerns/define_facility_params.rb
@@ -6,8 +6,10 @@ module DefineFacilityParams
   private
 
   def require_facility_params
+    # Raises ParameterMissing unless both are present. facility_category_id is
+    # optional and read directly in #set_category; there is no mass assignment
+    # in this flow, so there is nothing for permit to guard.
     params.require([:space_id, :facility_id])
-    params.permit([:facility_category_id])
     @space = Space.find(params[:space_id])
     @facility = Facility.find(params[:facility_id])
     @space_facility = SpaceFacility.find_by(space: @space, facility: @facility)

--- a/app/controllers/facility_reviews_controller.rb
+++ b/app/controllers/facility_reviews_controller.rb
@@ -29,8 +29,8 @@ class FacilityReviewsController < BaseControllers::AuthenticateController
   private
 
   def save_review_data
-    # Data to save:
-    params.permit(facility_review: [:user_id, :experience, :description])
+    # Data to save. Read as scalars and passed to update one key at a time
+    # below, so there is no mass assignment to permit.
     @user_id = params[:facility_review][:user_id]
     @experience = params[:facility_review][:experience]
     @description = params[:facility_review][:description]


### PR DESCRIPTION
Two `params.permit` calls discarded their return value, which made them inert. Found while investigating whether `Rails/StrongParametersExpect` was worth adopting.

## What they were doing: nothing

Verified in a runner rather than from docs:

| Check | Result |
|---|---|
| Does `permit` mutate `params`? | No — key set unchanged, `permitted?` still `false` |
| Does `permit` raise on a missing key? | No |
| Does `require([:a, :b])` raise when one is missing? | **Yes** — `ParameterMissing` |

So the two `permit` calls were dead, and the `require` above them is a genuine guard.

They also had nothing to guard even in principle. `permit` protects mass assignment, and neither flow mass-assigns:

- `facility_category_id` is read as a scalar in `#set_category`, behind a `present?` check
- `save_review_data` passes explicit keys one at a time — `update(description: @description)`, `update(experience: @experience)` — never a params hash

## Changes

- `define_facility_params.rb` — dropped `params.permit([:facility_category_id])`
- `facility_reviews_controller.rb` — dropped `params.permit(facility_review: [...])`
- Kept `params.require([:space_id, :facility_id])` and commented why it stays. It discards its return too, but it raises, so it is doing real work. The resemblance between the two lines is presumably how the dead `permit` came to sit next to it.

**Observable behaviour is unchanged.** Nothing consumed either return value, so no request can respond differently.

## Scope

A sweep of `app/controllers` found exactly three discarded `params.*` calls, all in these two files. Every other occurrence is the final expression of a `*_params` method — an implicit return, which is correct.

## Test coverage — honestly, partial

- Happy paths through both methods: covered by `spec/features/user_creates_facility_reviews_spec.rb` (6 examples, passing)
- The `require` guard: **not covered**. No spec exercises a missing `space_id` or `facility_id`, so nothing verifies the `ParameterMissing` behaviour.

Full suite: 381 examples, 0 failures. RuboCop: 0 offenses.

## Noticed, deliberately not changed

`@user_id = params[:facility_review][:user_id]` (line 34) is assigned and never read. The form submits a `user_id` hidden field, but the controller ignores it — `set_facility_review` uses `current_user`. Harmless, and safe as-is, but it reads as though client-supplied identity matters when it does not. Left alone to keep this diff to the one defect; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)