### PR TITLE
Move staging to PostGIS 18-3.6

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -22,6 +22,19 @@ env:
     POSTGRES_PORT: 5432
 accessories:
   db:
+    # PostgreSQL 18 ahead of production, which is still on the 15-3.3 defined in
+    # deploy.yml. Overridden here rather than there so the shared file keeps
+    # describing what production actually runs — otherwise any accessory command
+    # aimed at production would boot 18 against a 15 data directory and fail.
+    # Promote to deploy.yml once production has been migrated too.
+    #
+    # The mount path moves with the image: from 18 on these images keep data in
+    # a major-version subdirectory and expect a single mount at
+    # /var/lib/postgresql. Mounting the old .../data makes the container treat it
+    # as a stray volume and refuse to start.
+    image: postgis/postgis:18-3.6
+    directories:
+      - data:/var/lib/postgresql
     port: "127.0.0.1:5433:5432"
     env:
       clear:


### PR DESCRIPTION
Staging's database is migrated from PostgreSQL 15.4 / PostGIS 3.3 to **18.4 / 3.6.4**, as a rehearsal for production. Already applied — this PR is the config that backs it.

## Scoped to staging deliberately

The `db` accessory lives in `config/deploy.yml`, shared by both destinations. Overriding the image there would leave production's config claiming 18 while it still runs 15 — so any accessory command aimed at production would boot 18 against a 15 data directory and fail. The override sits in `deploy.staging.yml` until production is migrated too, then it moves to the shared file.

Verified per destination:

```
staging     image: postgis/postgis:18-3.6   dirs: data:/var/lib/postgresql
production  image: postgis/postgis:15-3.3   dirs: data:/var/lib/postgresql/data
```

## Procedure used

1. `pg_dump -Fc` → 28 MB from a 116 MB database
2. `kamal app stop` + `kamal accessory stop db`
3. Renamed the old data directory rather than deleting it — that's the rollback
4. This config change
5. `kamal accessory boot db` → fresh PG 18, `initdb` into `/var/lib/postgresql/18/docker`
6. `pg_restore --no-owner` → **completed with no errors at all**
7. `kamal app boot`

## Verification

Row counts across the schema:

| table | rows |
|---|---|
| spaces | 3444 |
| space_facilities | 216,972 |
| versions | 26,635 |
| space_contacts | 4,111 |
| users | 414 |
| schema_migrations | 96 |

`spaces` = 3444 matches exactly what the index showed before the migration.

And PostGIS proven functional, not merely present:

- `geo_point` populated on **3444 / 3444** rows
- `ST_AsText` → `POINT(8.9287 58.6261)`
- `ST_DWithin` within 50 km of Oslo → **675 spaces**, so spatial search works
- GiST index `index_spaces_on_geo_point` survived the restore
- `postgis_full_version()` → `3.6.4` on `PGSQL 180`

App is back up and behaving normally.

## Two findings that change the production runbook

**The data directory moves.** Kamal resolves accessory directories relative to the SSH user's home. The existing accessories were booted as **root** (`/root/<service>-db/data`), but Kamal now runs as `lokaler`, so a fresh boot creates `/home/lokaler/<service>-db/data`. Production's current data at `/root/production-lokaler-lnu-no-db/data` will therefore be left untouched as a free second backup — but it also means the new container would never read the old directory, so dump/restore is mandatory regardless of versions.

**`kamal accessory remove` must never appear in this procedure** — its own help says it removes "container, image and data directory".

Rollback, if ever needed: rename `data-pg15-backup` back to `data` **and** revert this commit. Both, not one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)