### PR TITLE
Move production to PostGIS 18-3.6

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -22,19 +22,6 @@ env:
     POSTGRES_PORT: 5432
 accessories:
   db:
-    # PostgreSQL 18 ahead of production, which is still on the 15-3.3 defined in
-    # deploy.yml. Overridden here rather than there so the shared file keeps
-    # describing what production actually runs — otherwise any accessory command
-    # aimed at production would boot 18 against a 15 data directory and fail.
-    # Promote to deploy.yml once production has been migrated too.
-    #
-    # The mount path moves with the image: from 18 on these images keep data in
-    # a major-version subdirectory and expect a single mount at
-    # /var/lib/postgresql. Mounting the old .../data makes the container treat it
-    # as a stray volume and refuse to start.
-    image: postgis/postgis:18-3.6
-    directories:
-      - data:/var/lib/postgresql
     port: "127.0.0.1:5433:5432"
     env:
       clear:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -56,7 +56,7 @@ volumes:
 asset_path: /rails/public/assets
 accessories:
   db:
-    image: postgis/postgis:15-3.3
+    image: postgis/postgis:18-3.6
     host: 95.216.137.182
     port: "127.0.0.1:5432:5432"
     env:
@@ -66,4 +66,4 @@ accessories:
       secret:
         - POSTGRES_PASSWORD
     directories:
-      - data:/var/lib/postgresql/data
+      - data:/var/lib/postgresql


### PR DESCRIPTION
Production's database is migrated from PostgreSQL 15.4 / PostGIS 3.3 to **18.4 / 3.6.4**. Already applied — this PR is the config behind it. Completes the last item in [LNU Lokaler: Vedlikehold 2026](https://3.basecamp.com/5846176/buckets/45552187/todosets/9436738197).

Promotes the accessory image and mount path from the staging override into the shared config and drops the override, since both destinations now want the same thing.

## Procedure

Staging was migrated first as a rehearsal ([#290](https://github.com/lnu-norge/lokaler.lnu.no/pull/290)), and the app deploy went out **before** the database moved — so the newer `activerecord-postgis-adapter` 11.1.1 / `rgeo` 3.1.0 were already in place rather than having the old gems meet a much newer PostGIS.

1. App deploy to production — 45.8s, **19/19 probes returned 200, zero downtime**
2. `pg_dump -Fc` → 42 MB from a 318 MB database
3. `kamal app stop` + `accessory stop` + `docker rm` the stopped container
4. This config change
5. `kamal accessory boot db` → fresh PG 18, `initdb` into `/var/lib/postgresql/18/docker`
6. `pg_restore --no-owner` → **no output, no errors**
7. `kamal app boot`

## Verification

| table | rows |
|---|---|
| spaces | 3507 |
| space_facilities | 220,941 |
| versions | 28,222 |
| space_contacts | 4,157 |
| users | 525 |
| images | 149 |
| schema_migrations | 96 |

PostGIS proven functional rather than merely installed:

- `geo_point` populated on **3507 / 3507** rows
- `ST_AsText` → `POINT(10.76078 59.9134)`, central Oslo
- `ST_DWithin` within 50 km of Oslo → **691 spaces**
- GiST index `index_spaces_on_geo_point` survived the restore
- `postgis_version()` → `3.6`

## No rename needed this time

Kamal resolves accessory directories relative to the SSH user's home. The old accessories were booted as **root**, but Kamal now runs as `lokaler`, so the new container binds `/home/lokaler/production-lokaler-lnu-no-db/data` while the previous data stays untouched at `/root/production-lokaler-lnu-no-db/data`. That is a second rollback path alongside the dump — and it also confirms dump/restore was unavoidable, since the new container would never have read the old directory regardless of version.

## Cleanup still pending

Once you are satisfied, these can go:

- `/root/production-lokaler-lnu-no-db/data` (~318 MB) and `/root/staging-db/data-pg15-backup`
- `~/production-pg15-20260804-0901.dump` and `~/staging-pg15-20260804-0843.dump`

Deliberately left in place for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)